### PR TITLE
Review comments M1-M3

### DIFF
--- a/src/main/assembly/dist/cfg/config.yml
+++ b/src/main/assembly/dist/cfg/config.yml
@@ -15,3 +15,5 @@ server:
     - type: http
       # Replace with port number unique for this service
       port: 20001
+
+# Provide reasonable defaults for non-optional settings

--- a/src/main/java/nl/knaw/dans/ttv/DdTransferToVaultApplication.java
+++ b/src/main/java/nl/knaw/dans/ttv/DdTransferToVaultApplication.java
@@ -97,6 +97,7 @@ public class DdTransferToVaultApplication extends Application<DdTransferToVaultC
         }
         tasks.sort(Inbox.TASK_QUEUE_DATE_COMPARATOR);
         tasks.forEach(executorService::execute);
+        // Inbox watchers should each execute on their own thread instead of using the threadpool  of the tasks
         inboxWatchers.forEach(executorService::execute);
     }
 

--- a/src/main/java/nl/knaw/dans/ttv/DdTransferToVaultApplication.java
+++ b/src/main/java/nl/knaw/dans/ttv/DdTransferToVaultApplication.java
@@ -72,15 +72,17 @@ public class DdTransferToVaultApplication extends Application<DdTransferToVaultC
         List<Inbox> inboxes = new ArrayList<>();
         List<InboxWatcher> inboxWatchers = new ArrayList<>();
 
-        //Initialize inboxes
+        //Initialize inboxes <- comment doesn't really say a whole lot, listen to Uncle Bob and remove it.
         for (Map<String, String> inbox : configuration.getInboxes()) {
             Inbox newInbox = new UnitOfWorkAwareProxyFactory(hibernateBundle)
                     .create(Inbox.class, new Class[] {String.class, Path.class}, new Object[] {inbox.get("name"), Paths.get(inbox.get("path"))});
             inboxes.add(newInbox);
             try {
+                // The watch service to use is always FileSystems.getDefault().newWatchService(), yet is is passed in as parameter
                 inboxWatchers.add(new InboxWatcher(newInbox, executorService, FileSystems.getDefault().newWatchService()));
             } catch (IOException e) {
                 // I will not see this if the service starts up normally otherwise
+                // This is only thrown by FileSystems.getDefault().newWatchService(), not by teh InboxWatcher constructor.
                 log.error(e.getMessage(), e);
             }
         }

--- a/src/main/java/nl/knaw/dans/ttv/DdTransferToVaultApplication.java
+++ b/src/main/java/nl/knaw/dans/ttv/DdTransferToVaultApplication.java
@@ -80,6 +80,7 @@ public class DdTransferToVaultApplication extends Application<DdTransferToVaultC
             try {
                 inboxWatchers.add(new InboxWatcher(newInbox, executorService, FileSystems.getDefault().newWatchService()));
             } catch (IOException e) {
+                // I will not see this if the service starts up normally otherwise
                 log.error(e.getMessage(), e);
             }
         }

--- a/src/main/java/nl/knaw/dans/ttv/DdTransferToVaultApplication.java
+++ b/src/main/java/nl/knaw/dans/ttv/DdTransferToVaultApplication.java
@@ -16,7 +16,6 @@
 
 package nl.knaw.dans.ttv;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.Application;
 import io.dropwizard.db.PooledDataSourceFactory;
 import io.dropwizard.hibernate.HibernateBundle;
@@ -27,7 +26,6 @@ import nl.knaw.dans.ttv.core.Inbox;
 import nl.knaw.dans.ttv.core.InboxWatcher;
 import nl.knaw.dans.ttv.core.Task;
 import nl.knaw.dans.ttv.core.TransferItem;
-import nl.knaw.dans.ttv.core.TransferTask;
 import nl.knaw.dans.ttv.db.TransferItemDAO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/nl/knaw/dans/ttv/DdTransferToVaultConfiguration.java
+++ b/src/main/java/nl/knaw/dans/ttv/DdTransferToVaultConfiguration.java
@@ -18,13 +18,11 @@ package nl.knaw.dans.ttv;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.Configuration;
-import nl.knaw.dans.lib.util.ExecutorServiceFactory;
 import io.dropwizard.db.DataSourceFactory;
-import nl.knaw.dans.ttv.core.Inbox;
+import nl.knaw.dans.lib.util.ExecutorServiceFactory;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/nl/knaw/dans/ttv/core/Inbox.java
+++ b/src/main/java/nl/knaw/dans/ttv/core/Inbox.java
@@ -16,11 +16,10 @@
 package nl.knaw.dans.ttv.core;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import nl.knaw.dans.ttv.db.TransferItemDAO;
-import org.apache.commons.codec.digest.DigestUtils;
 import io.dropwizard.hibernate.UnitOfWork;
 import io.dropwizard.hibernate.UnitOfWorkAwareProxyFactory;
 import nl.knaw.dans.ttv.db.TransferItemDAO;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.hibernate.SessionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -160,5 +159,5 @@ public class Inbox {
                 ", path=" + path +
                 '}';
     }
-    
+
 }

--- a/src/main/java/nl/knaw/dans/ttv/core/Inbox.java
+++ b/src/main/java/nl/knaw/dans/ttv/core/Inbox.java
@@ -160,4 +160,5 @@ public class Inbox {
                 ", path=" + path +
                 '}';
     }
+    
 }

--- a/src/main/java/nl/knaw/dans/ttv/core/InboxWatcher.java
+++ b/src/main/java/nl/knaw/dans/ttv/core/InboxWatcher.java
@@ -19,17 +19,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.nio.file.FileSystems;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardWatchEventKinds;
-import java.nio.file.WatchEvent;
 import java.nio.file.WatchKey;
 import java.nio.file.WatchService;
-import java.util.Optional;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
 
 public class InboxWatcher implements Runnable {
 

--- a/src/main/java/nl/knaw/dans/ttv/core/InboxWatcher.java
+++ b/src/main/java/nl/knaw/dans/ttv/core/InboxWatcher.java
@@ -47,10 +47,10 @@ public class InboxWatcher implements Runnable {
         while (true) {
             key = watchService.take();
             key.pollEvents().stream()
-                    .map(watchEvent -> ((Path) watchEvent.context()))
-                    .filter(path -> path.getFileName().toString().endsWith(".zip"))
-                    .map(path -> inbox.createTransferItemTask(inbox.getPath().resolve(path.getFileName())))
-                            .forEach(executorService::execute);
+                .map(watchEvent -> ((Path) watchEvent.context()))
+                .filter(path -> path.getFileName().toString().endsWith(".zip"))
+                .map(path -> inbox.createTransferItemTask(inbox.getPath().resolve(path.getFileName())))
+                .forEach(executorService::execute);
             key.reset();
         }
     }
@@ -59,7 +59,8 @@ public class InboxWatcher implements Runnable {
     public void run() {
         try {
             startWatchService();
-        } catch (IOException | InterruptedException e) {
+        }
+        catch (IOException | InterruptedException e) {
             // You are not recovering the error, so I'd just rethrow it as an unchecked exception
             log.error(e.getMessage(), e);
         }

--- a/src/main/java/nl/knaw/dans/ttv/core/InboxWatcher.java
+++ b/src/main/java/nl/knaw/dans/ttv/core/InboxWatcher.java
@@ -43,6 +43,7 @@ public class InboxWatcher implements Runnable {
         inbox.getPath().register(watchService, StandardWatchEventKinds.ENTRY_CREATE);
 
         WatchKey key;
+        // IntelliJ: while statement cannot complete without exception
         while (true) {
             key = watchService.take();
             key.pollEvents().stream()
@@ -59,6 +60,7 @@ public class InboxWatcher implements Runnable {
         try {
             startWatchService();
         } catch (IOException | InterruptedException e) {
+            // You are not recovering the error, so I'd just rethrow it as an unchecked exception
             log.error(e.getMessage(), e);
         }
     }

--- a/src/main/java/nl/knaw/dans/ttv/core/Task.java
+++ b/src/main/java/nl/knaw/dans/ttv/core/Task.java
@@ -18,8 +18,6 @@ package nl.knaw.dans.ttv.core;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import nl.knaw.dans.ttv.db.TransferItemDAO;
 
-import java.util.concurrent.Callable;
-
 public abstract class Task implements Runnable {
 
     protected final TransferItem transferItem;

--- a/src/main/java/nl/knaw/dans/ttv/core/TransferItem.java
+++ b/src/main/java/nl/knaw/dans/ttv/core/TransferItem.java
@@ -15,7 +15,6 @@
  */
 package nl.knaw.dans.ttv.core;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,11 +29,9 @@ import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
-import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Objects;
-import java.util.Optional;
 
 @Entity
 @Table(name = "transfer_queue", uniqueConstraints={@UniqueConstraint(columnNames = {"dataset_pid" , "version_major", "version_minor"})})

--- a/src/test/java/nl/knaw/dans/ttv/core/TransferTaskTest.java
+++ b/src/test/java/nl/knaw/dans/ttv/core/TransferTaskTest.java
@@ -15,28 +15,18 @@
  */
 package nl.knaw.dans.ttv.core;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.hibernate.UnitOfWorkAwareProxyFactory;
 import io.dropwizard.testing.junit5.DAOTestExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import nl.knaw.dans.ttv.db.TransferItemDAO;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
 class TransferTaskTest {


### PR DESCRIPTION
@mderuijter : here are my comments on the code merged so far (M1 through M3). Feel free to react if you think I misunderstood, or if you don't understand my point.

I will not merge this PR, it only serves as an anchor for my comments. After you have addressed them, this PR will be closed.

Tidiness/clarity
===========
* Keep your imports organized
* Provide "reasonable defaults" for non-optional settings in [`src/main/assembly/dist/cfg/config.yml`](https://github.com/DANS-KNAW/dd-transfer-to-vault/pull/8/files#diff-c6999ba05cd8664a16a192f61fee43722a1f14de4c1c91df73267913abf286b5R19). If one installs the package via yum it should as much as possible be ready to run. So, there should be some default database config, etc. This will not necessarily be the config that we use (so hsqldb could be used as a default). Our Ansible script will override what is necessary in our own case. What I want you to do for the reasonable defaults is take the view of a hypothetical external user who installs our package. For passwords choose the value "changeme" to make it plain that this is not actually very "reasonable" as a default.
* Rename `jobQueue` to `taskQueue`. I think we discussed this earlier. The code executes things called "Tasks", but somehow the queue that executes them refers to "Jobs". This requires the reader of code to understand that jobs and tasks are the same thing.
* [IntelliJ warns that this loop can only terminate with an exception](https://github.com/DANS-KNAW/dd-transfer-to-vault/pull/8/files#diff-760cc9c3d5072d84f9b0d8c0d6fc8bebbd35c1a275f167665feac5f29b5542bcR46). I think it will probably be run in a [daemon thread](https://docs.oracle.com/javase/8/docs/api/java/lang/Thread.html#setDaemon-boolean-) and therefore be removed by the JVM when exiting. It might also terminate with a `ClosedWatchServiceException` if `take()` happens to be called when the watch service is closed. It is better to try and close each thread as cleanly as possible. I am not sure about the exact solution yet, but I think part of it is that you need to make the `InboxWatcher`s managed using `environment.lifecycle().manage()`.
    

Functionality
==========
* Don't start up unless **all** inboxes can be watched. If the service seems to start up OK, as an admin I will in all likelihood **not** inspect the logs. However, the current code requires me to do so in order to make sure that there wasn't an [IOException when one of the inboxes tried to start](https://github.com/DANS-KNAW/dd-transfer-to-vault/pull/8/files#diff-27a79855df9758a31bc1821593d3d952fd0921bb7cf1f80d6892eaaf7627b535R83).
* By the way, the InboxWatcher constructors don't throw the IOException, `FileSystems.getDefault().newWatchService()` does. It is passed in a a parameter but the watch service is not configurable. At this point I don't think it needs to be configurable, so just put the call to `FileSystems.getDefault().newWatchService()`  in the `InboxWatcher` constructor for now. (We can always make it configurable later, if the need arises.)
* The taskQueue threadpool is now shared by the [inbox watchers](https://github.com/DANS-KNAW/dd-transfer-to-vault/pull/8/files#diff-27a79855df9758a31bc1821593d3d952fd0921bb7cf1f80d6892eaaf7627b535R100). This is at minimum confusing at at worst it means there are no threads left in the pool for any tasks to be executed (if you set maxThreads to the number of inboxes).



