### PR TITLE
Review M1-M4

### DIFF
--- a/src/main/assembly/dist/cfg/config.yml
+++ b/src/main/assembly/dist/cfg/config.yml
@@ -37,9 +37,11 @@ taskQueue:
   keepAliveTime: 60 seconds
 
 inboxes:
-  - name: Test
-    path: src/test/resources/data/inbox
+# Add inboxes with the following properties
+#  - name: inboxname
+#    path: /path/to/inbox
 
 outboxes:
-  transferOutboxPath: src/test/resources/data/outbox
-  ocflWorkPath: src/test/resources/data/workdir
+# Multiple outboxes, but not a list??
+#  transferOutboxPath: src/test/resources/data/outbox
+#  ocflWorkPath: src/test/resources/data/workdir

--- a/src/main/assembly/dist/install/dd-transfer-to-vault.service
+++ b/src/main/assembly/dist/install/dd-transfer-to-vault.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=${project.name} Service
+Description=Transfer To Vault Service
 
 [Service]
 ExecStart=/opt/dans.knaw.nl/dd-transfer-to-vault/bin/dd-transfer-to-vault server /etc/opt/dans.knaw.nl/dd-transfer-to-vault/config.yml


### PR DESCRIPTION
@mderuijter : here are my comments on the code merged so far (M1 through M4). Feel free to react if you think I misunderstood, or if you don't understand my point. Some points refer back to my [previous review](https://github.com/DANS-KNAW/dd-transfer-to-vault/pull/8)

I will not merge this PR, it only serves as an anchor for my comments. After you have addressed them, this PR will be closed.

# Tidiness/clarity
* Provide "reasonable defaults" for non-optional settings in src/main/assembly/dist/cfg/config.yml. The defaults that you provided refer to the project directory (`src/test/...` etc). Obviously, those don't exist in a production environment. Why did you pick these values?
* `jobQueue` rename to `taskQueue` -> OK.
* See bullet about [IntelliJ warns that this loop can only terminate with an exception.](https://github.com/DANS-KNAW/dd-transfer-to-vault/pull/8). I think you were almost there. The point of the `Managed` interface is that you implement `stop` to clean up. In this case it is the opportunity to let your loop terminate and close the watcher. Something like I do in this PR. 


# Functionality
* The taskQueue threadpool is now shared by the inbox watchers (see previous review). You haven't addressed this.



