### PR TITLE
Dd 826 collect workdir

### DIFF
--- a/debug-init-env.sh
+++ b/debug-init-env.sh
@@ -23,6 +23,7 @@ echo "OK"
 echo - n "Pre-creating work directories..."
 mkdir -p $TEMPDIR/tmp/transfer-inboxes/inbox1
 mkdir -p $TEMPDIR/tmp/transfer-inboxes/inbox2
+mkdir -p $TEMPDIR/tmp/collect-workdir
 mkdir -p $TEMPDIR/tmp/ocfl-tar-inbox
 mkdir -p $TEMPDIR/tmp/ocfl-tar-workdirs
 echo "OK"

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>edu.wisc.library.ocfl</groupId>
             <artifactId>ocfl-java-core</artifactId>
-            <version>1.4.1</version>
+            <version>1.4.4</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>
@@ -109,6 +109,11 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/assembly/dist/cfg/config.yml
+++ b/src/main/assembly/dist/cfg/config.yml
@@ -2,6 +2,7 @@ collect:
   inboxes:
     - name: DS_Archaeology
       path: /var/opt/dans.knaw.nl/tmp/transfer-inboxes/archaeology
+  workDir: /var/opt/dans.knaw.nl/tmp/collect-work-dir
   # polling interval in milliseconds
   pollingInterval: 500
   taskQueue:

--- a/src/main/assembly/dist/cfg/config.yml
+++ b/src/main/assembly/dist/cfg/config.yml
@@ -1,12 +1,23 @@
 collect:
-  inboxes:
-    - name: DS_Archaeology
-      path: /var/opt/dans.knaw.nl/tmp/transfer-inboxes/archaeology
-  workDir: /var/opt/dans.knaw.nl/tmp/collect-work-dir
+  inboxes: []
   # polling interval in milliseconds
   pollingInterval: 500
   taskQueue:
-    nameFormat: "add-worker-thread-%d"
+    nameFormat: "collect-worker-%d"
+    maxQueueSize: 5000
+    # Number of threads will be increased when maxQueueSize is exceeded.
+    minThreads: 1
+    # No more than maxThreads will be created though
+    maxThreads: 10
+    # Threads will die after 60 seconds of idleness
+    keepAliveTime: 60 seconds
+
+metadata:
+  inbox: /var/opt/dans.knaw.nl/tmp/metadata-inbox
+  # polling interval in milliseconds
+  pollingInterval: 500
+  taskQueue:
+    nameFormat: "metadata-worker-thread-%d"
     maxQueueSize: 5000
     # Number of threads will be increased when maxQueueSize is exceeded.
     minThreads: 1
@@ -19,14 +30,14 @@ dataArchive:
   baseDir: 'danstst0@archive.surfsara.nl:'
 
 createOcflTar:
-  inbox: /var/opt/dans.knaw.nl/tmp/ocfl-directories/ocfl-storage-root
-  workDir: /var/opt/dans.knaw.nl/tmp/ocfl-directories/ocfl-work-dir
+  inbox: /var/opt/dans.knaw.nl/tmp/ocfl-tar/inbox
+  workDir: /var/opt/dans.knaw.nl/tmp/ocfl-tar/workdirs
   inboxThreshold: 2G
   tarCommand: 'dmftar -c -f %s %s' # target, source
   # polling interval in milliseconds
   pollingInterval: 500
   taskQueue:
-    nameFormat: "ocfl-tar-thread-%d"
+    nameFormat: "ocfl-tar-worker-%d"
     maxQueueSize: 5000
     # Number of threads will be increased when maxQueueSize is exceeded.
     minThreads: 1
@@ -38,7 +49,7 @@ createOcflTar:
 confirmArchived:
   cron: '0 0 * * * ?' # cron expression for triggering a polling round
   taskQueue:
-    nameFormat: "confirm-thread-%d"
+    nameFormat: "confirm-archived-worker-%d"
     maxQueueSize: 5000
     # Number of threads will be increased when maxQueueSize is exceeded.
     minThreads: 1
@@ -50,8 +61,8 @@ confirmArchived:
 database:
   driverClass: org.postgresql.Driver
   url: jdbc:postgresql://localhost:5432/dd_transfer_to_vault
-  user: change_me
-  password: change_me
+  user: changeme
+  password: changeme
   logValidationErrors: true
   properties:
     hibernate.dialect: 'org.hibernate.dialect.PostgreSQL95Dialect'

--- a/src/main/java/nl/knaw/dans/ttv/DdTransferToVaultApplication.java
+++ b/src/main/java/nl/knaw/dans/ttv/DdTransferToVaultApplication.java
@@ -81,6 +81,7 @@ public class DdTransferToVaultApplication extends Application<DdTransferToVaultC
         // the Collect task, which listens to new files on the network-drive shares
         var collectTaskManager = new CollectTaskManager(
             configuration.getCollect().getInboxes(),
+            configuration.getCollect().getWorkDir(),
             configuration.getCreateOcflTar().getInbox(),
             configuration.getCollect().getPollingInterval(),
             collectExecutorService,

--- a/src/main/java/nl/knaw/dans/ttv/DdTransferToVaultConfiguration.java
+++ b/src/main/java/nl/knaw/dans/ttv/DdTransferToVaultConfiguration.java
@@ -22,6 +22,7 @@ import io.dropwizard.db.DataSourceFactory;
 import nl.knaw.dans.ttv.core.config.CollectConfiguration;
 import nl.knaw.dans.ttv.core.config.ConfirmArchivedConfiguration;
 import nl.knaw.dans.ttv.core.config.CreateOcflTarConfiguration;
+import nl.knaw.dans.ttv.core.config.MetadataConfiguration;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -36,6 +37,10 @@ public class DdTransferToVaultConfiguration extends Configuration {
     @Valid
     @NotNull
     private CollectConfiguration collect;
+
+    @Valid
+    @NotNull
+    private MetadataConfiguration metadata;
 
     @Valid
     @NotNull
@@ -78,5 +83,13 @@ public class DdTransferToVaultConfiguration extends Configuration {
 
     public void setDataArchiveRoot(Map<String, String> dataArchive) {
         this.dataArchiveRoot = dataArchive.get("baseDir");
+    }
+
+    public MetadataConfiguration getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(MetadataConfiguration metadata) {
+        this.metadata = metadata;
     }
 }

--- a/src/main/java/nl/knaw/dans/ttv/core/CollectTask.java
+++ b/src/main/java/nl/knaw/dans/ttv/core/CollectTask.java
@@ -52,8 +52,8 @@ public class CollectTask implements Runnable {
         try {
             var workDirFile = moveFileToWorkDir(this.filePath, this.workDir);
             var transferItem = createTransferItem(workDirFile);
-            cleanUpXmlFile(this.filePath);
             moveFileToOutbox(transferItem, workDirFile, this.outbox);
+            cleanUpXmlFile(this.filePath);
         }
         catch (IOException | InvalidTransferItemException e) {
             log.error("unable to create TransferItem for path {}", this.filePath, e);

--- a/src/main/java/nl/knaw/dans/ttv/core/ConfirmArchivedTask.java
+++ b/src/main/java/nl/knaw/dans/ttv/core/ConfirmArchivedTask.java
@@ -33,11 +33,11 @@ public class ConfirmArchivedTask implements Runnable {
     private final TransferItemService transferItemService;
     private final ArchiveStatusService archiveStatusService;
     private final OcflRepositoryService ocflRepositoryService;
-    private final String workingDir;
+    private final Path workingDir;
     private final String dataArchiveRoot;
 
     public ConfirmArchivedTask(String tarId, TransferItemService transferItemService, ArchiveStatusService archiveStatusService, OcflRepositoryService ocflRepositoryService,
-        String workingDir, String dataArchiveRoot) {
+        Path workingDir, String dataArchiveRoot) {
         this.transferItemService = transferItemService;
         this.archiveStatusService = archiveStatusService;
         this.ocflRepositoryService = ocflRepositoryService;
@@ -60,7 +60,7 @@ public class ConfirmArchivedTask implements Runnable {
 
                 try {
                     log.info("cleaning workdir files and folders for tar archive '{}'", tarId);
-                    ocflRepositoryService.cleanupRepository(Path.of(workingDir), tarId);
+                    ocflRepositoryService.cleanupRepository(workingDir, tarId);
                 } catch (IOException e) {
                     log.error("unable to cleanup TAR OCFL repository in directory '{}/{}'", workingDir, tarId, e);
                 }

--- a/src/main/java/nl/knaw/dans/ttv/core/ConfirmArchivedTaskCreator.java
+++ b/src/main/java/nl/knaw/dans/ttv/core/ConfirmArchivedTaskCreator.java
@@ -24,6 +24,7 @@ import org.quartz.JobExecutionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.file.Path;
 import java.util.concurrent.ExecutorService;
 
 public class ConfirmArchivedTaskCreator implements Job {
@@ -33,7 +34,7 @@ public class ConfirmArchivedTaskCreator implements Job {
     public void execute(JobExecutionContext context) throws JobExecutionException {
         var dataMap = context.getMergedJobDataMap();
         var transferItemService = (TransferItemService) dataMap.get("transferItemService");
-        var workingDir = (String) dataMap.get("workingDir");
+        var workingDir = (Path) dataMap.get("workingDir");
         var dataArchiveRoot = (String) dataMap.get("dataArchiveRoot");
         var archiveStatusService = (ArchiveStatusService) dataMap.get("archiveStatusService");
         var ocflRepositoryService = (OcflRepositoryService) dataMap.get("ocflRepositoryService");

--- a/src/main/java/nl/knaw/dans/ttv/core/ConfirmArchivedTaskManager.java
+++ b/src/main/java/nl/knaw/dans/ttv/core/ConfirmArchivedTaskManager.java
@@ -31,6 +31,7 @@ import org.quartz.impl.StdSchedulerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.file.Path;
 import java.util.concurrent.ExecutorService;
 
 public class ConfirmArchivedTaskManager implements Managed {
@@ -39,14 +40,14 @@ public class ConfirmArchivedTaskManager implements Managed {
     private Scheduler scheduler;
     private final String schedule;
 
-    private final String workingDir;
+    private final Path workingDir;
     private final String dataArchiveRoot;
     private final ExecutorService executorService;
     private final TransferItemService transferItemService;
     private final ArchiveStatusService archiveStatusService;
     private final OcflRepositoryService ocflRepositoryService;
 
-    public ConfirmArchivedTaskManager(String schedule, String workingDir, String dataArchiveRoot,
+    public ConfirmArchivedTaskManager(String schedule, Path workingDir, String dataArchiveRoot,
         ExecutorService executorService, TransferItemService transferItemService, ArchiveStatusService archiveStatusService, OcflRepositoryService ocflRepositoryService) {
 
         this.workingDir = workingDir;

--- a/src/main/java/nl/knaw/dans/ttv/core/MetadataTask.java
+++ b/src/main/java/nl/knaw/dans/ttv/core/MetadataTask.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2021 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.ttv.core;
+
+import nl.knaw.dans.ttv.core.service.FileService;
+import nl.knaw.dans.ttv.core.service.TransferItemMetadataReader;
+import nl.knaw.dans.ttv.core.service.TransferItemService;
+import nl.knaw.dans.ttv.db.TransferItem;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+public class MetadataTask implements Runnable {
+    private static final Logger log = LoggerFactory.getLogger(MetadataTask.class);
+
+    private final Path filePath;
+    private final Path outbox;
+    private final TransferItemService transferItemService;
+    private final TransferItemMetadataReader metadataReader;
+    private final FileService fileService;
+
+    public MetadataTask(Path filePath, Path outbox, TransferItemService transferItemService,
+        TransferItemMetadataReader metadataReader, FileService fileService) {
+        this.filePath = filePath;
+        this.outbox = outbox;
+        this.transferItemService = transferItemService;
+        this.metadataReader = metadataReader;
+        this.fileService = fileService;
+    }
+
+    @Override
+    public void run() {
+        try {
+            processFile(this.filePath);
+        }
+        catch (IOException | InvalidTransferItemException e) {
+            log.error("unable to create TransferItem for path '{}'", this.filePath, e);
+            // TODO move to deadletter box
+        }
+    }
+
+    void processFile(Path path) throws IOException, InvalidTransferItemException {
+        var transferItem = getTransferItem(path);
+
+        if (
+            transferItem.getTransferStatus() != TransferItem.TransferStatus.COLLECTED
+                && transferItem.getTransferStatus() != TransferItem.TransferStatus.CREATED
+        ) {
+            throw new InvalidTransferItemException(String.format("TransferItem already exists but with an unexpected status: %s", transferItem));
+        }
+
+        // we only expect items with status CREATED, but if they are already COLLECTED we
+        // can just read the metadata again and update the TransferItem before moving
+        var filesystemAttributes = metadataReader.getFilesystemAttributes(path);
+        log.trace("received filesystem attributes: {}", filesystemAttributes);
+        var fileContentAttributes = metadataReader.getFileContentAttributes(path);
+        log.trace("received file content attributes: {}", fileContentAttributes);
+
+        var newPath = outbox.resolve(filePath.getFileName());
+
+        transferItemService.addMetadataAndMoveFile(
+            transferItem,
+            filesystemAttributes,
+            fileContentAttributes,
+            TransferItem.TransferStatus.COLLECTED,
+            newPath
+        );
+
+        fileService.moveFile(path, newPath);
+    }
+
+    public TransferItem getTransferItem(Path path) throws InvalidTransferItemException {
+        var filenameAttributes = metadataReader.getFilenameAttributes(path);
+        log.trace("received filename attributes: {}", filenameAttributes);
+
+        return transferItemService.getTransferItemByFilenameAttributes(filenameAttributes)
+            .orElseThrow(() -> new InvalidTransferItemException(String.format("no TransferItem found for filename attributes %s", filenameAttributes)));
+    }
+
+}

--- a/src/main/java/nl/knaw/dans/ttv/core/config/CollectConfiguration.java
+++ b/src/main/java/nl/knaw/dans/ttv/core/config/CollectConfiguration.java
@@ -24,6 +24,7 @@ import javax.validation.Valid;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
+import java.nio.file.Path;
 import java.util.List;
 
 public class CollectConfiguration {
@@ -44,6 +45,18 @@ public class CollectConfiguration {
     @NotNull
     @Min(1)
     private long pollingInterval;
+
+    @Valid
+    @NotNull
+    private Path workDir;
+
+    public Path getWorkDir() {
+        return workDir;
+    }
+
+    public void setWorkDir(Path workDir) {
+        this.workDir = workDir;
+    }
 
     public long getPollingInterval() {
         return pollingInterval;
@@ -71,13 +84,13 @@ public class CollectConfiguration {
 
     public static class InboxEntry {
         private String name;
-        private String path;
+        private Path path;
 
         public InboxEntry() {
 
         }
 
-        public InboxEntry(String name, String path) {
+        public InboxEntry(String name, Path path) {
             this.name = name;
             this.path = path;
         }
@@ -90,11 +103,11 @@ public class CollectConfiguration {
             this.name = name;
         }
 
-        public String getPath() {
+        public Path getPath() {
             return path;
         }
 
-        public void setPath(String path) {
+        public void setPath(Path path) {
             this.path = path;
         }
 

--- a/src/main/java/nl/knaw/dans/ttv/core/config/CreateOcflTarConfiguration.java
+++ b/src/main/java/nl/knaw/dans/ttv/core/config/CreateOcflTarConfiguration.java
@@ -22,16 +22,17 @@ import nl.knaw.dans.ttv.core.config.converter.StringByteSizeConverter;
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
+import java.nio.file.Path;
 
 public class CreateOcflTarConfiguration {
 
     @Valid
     @NotNull
-    private String inbox;
+    private Path inbox;
 
     @Valid
     @NotNull
-    private String workDir;
+    private Path workDir;
 
     @Valid
     @NotNull
@@ -58,19 +59,19 @@ public class CreateOcflTarConfiguration {
         this.pollingInterval = pollingInterval;
     }
 
-    public String getInbox() {
+    public Path getInbox() {
         return inbox;
     }
 
-    public void setInbox(String inbox) {
+    public void setInbox(Path inbox) {
         this.inbox = inbox;
     }
 
-    public String getWorkDir() {
+    public Path getWorkDir() {
         return workDir;
     }
 
-    public void setWorkDir(String workDir) {
+    public void setWorkDir(Path workDir) {
         this.workDir = workDir;
     }
 

--- a/src/main/java/nl/knaw/dans/ttv/core/config/MetadataConfiguration.java
+++ b/src/main/java/nl/knaw/dans/ttv/core/config/MetadataConfiguration.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2021 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.ttv.core.config;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import nl.knaw.dans.lib.util.ExecutorServiceFactory;
+
+import javax.validation.Valid;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import java.nio.file.Path;
+
+public class MetadataConfiguration {
+    @Valid
+    @NotNull
+    private Path inbox;
+
+    @Valid
+    @NotNull
+    @JsonProperty("taskQueue")
+    private ExecutorServiceFactory taskQueue;
+
+    @Valid
+    @NotNull
+    @Min(1)
+    private long pollingInterval;
+
+    public long getPollingInterval() {
+        return pollingInterval;
+    }
+
+    public void setPollingInterval(long pollingInterval) {
+        this.pollingInterval = pollingInterval;
+    }
+
+    public ExecutorServiceFactory getTaskQueue() {
+        return taskQueue;
+    }
+
+    public void setTaskQueue(ExecutorServiceFactory taskQueue) {
+        this.taskQueue = taskQueue;
+    }
+
+    public Path getInbox() {
+        return inbox;
+    }
+
+    public void setInbox(Path inbox) {
+        this.inbox = inbox;
+    }
+}

--- a/src/main/java/nl/knaw/dans/ttv/core/service/FileService.java
+++ b/src/main/java/nl/knaw/dans/ttv/core/service/FileService.java
@@ -41,4 +41,6 @@ public interface FileService {
     ZipFile openZipFile(Path path) throws IOException;
 
     InputStream openFileFromZip(ZipFile datasetVersionExport, Path of) throws IOException;
+
+    Path moveFileAtomically(Path filePath, Path newPath) throws IOException;
 }

--- a/src/main/java/nl/knaw/dans/ttv/core/service/FileServiceImpl.java
+++ b/src/main/java/nl/knaw/dans/ttv/core/service/FileServiceImpl.java
@@ -39,6 +39,17 @@ public class FileServiceImpl implements FileService {
     }
 
     @Override
+    public Path moveFileAtomically(Path filePath, Path newPath) throws IOException {
+        var tempTarget = Path.of(newPath.toString() + ".part");
+
+        // there could be leftovers from a previous attempt, remove them
+        Files.deleteIfExists(tempTarget);
+
+        moveFile(filePath, tempTarget);
+        return moveFile(tempTarget, newPath);
+    }
+
+    @Override
     public boolean deleteFile(Path path) throws IOException {
         Objects.requireNonNull(path, "path cannot be null");
         log.trace("deleting file {}", path);

--- a/src/main/java/nl/knaw/dans/ttv/core/service/TransferItemService.java
+++ b/src/main/java/nl/knaw/dans/ttv/core/service/TransferItemService.java
@@ -23,6 +23,7 @@ import nl.knaw.dans.ttv.db.TransferItem;
 
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Optional;
 
 public interface TransferItemService {
 
@@ -31,6 +32,9 @@ public interface TransferItemService {
     List<TransferItem> findByTarId(String id);
 
     TransferItem createTransferItem(String datastationName, FilenameAttributes filenameAttributes, FilesystemAttributes filesystemAttributes, FileContentAttributes fileContentAttributes)
+        throws InvalidTransferItemException;
+
+    TransferItem createTransferItem(String datastationName, FilenameAttributes filenameAttributes)
         throws InvalidTransferItemException;
 
     TransferItem moveTransferItem(TransferItem transferItem, TransferItem.TransferStatus newStatus, Path newPath);
@@ -42,4 +46,8 @@ public interface TransferItemService {
     List<String> stageAllTarsToBeConfirmed();
 
     void updateCheckingProgressResults(String id, TransferItem.TransferStatus status);
+
+    Optional<TransferItem> getTransferItemByFilenameAttributes(FilenameAttributes filenameAttributes);
+
+    TransferItem addMetadataAndMoveFile(TransferItem transferItem, FilesystemAttributes filesystemAttributes, FileContentAttributes fileContentAttributes, TransferItem.TransferStatus status, Path newPath);
 }

--- a/src/main/java/nl/knaw/dans/ttv/core/service/TransferItemServiceImpl.java
+++ b/src/main/java/nl/knaw/dans/ttv/core/service/TransferItemServiceImpl.java
@@ -55,7 +55,8 @@ public class TransferItemServiceImpl implements TransferItemService {
     public TransferItem createTransferItem(String datastationName, FilenameAttributes filenameAttributes, FilesystemAttributes filesystemAttributes, FileContentAttributes fileContentAttributes)
         throws InvalidTransferItemException {
         var transferItem = new TransferItem();
-        transferItem.setTransferStatus(TransferItem.TransferStatus.EXTRACT);
+
+        transferItem.setTransferStatus(TransferItem.TransferStatus.COLLECTED);
         transferItem.setQueueDate(LocalDateTime.now());
         transferItem.setDatasetDvInstance(datastationName);
 

--- a/src/main/java/nl/knaw/dans/ttv/db/TransferItem.java
+++ b/src/main/java/nl/knaw/dans/ttv/db/TransferItem.java
@@ -39,6 +39,7 @@ public class TransferItem {
     private static final Logger log = LoggerFactory.getLogger(TransferItem.class);
 
     public enum TransferStatus {
+        CREATED,
         COLLECTED,
         TARRING,
         OCFLTARCREATED,
@@ -61,7 +62,7 @@ public class TransferItem {
     @Column(name = "version_minor", nullable = false)
     private int versionMinor;
 
-    @Column(name = "creation_time", nullable = false)
+    @Column(name = "creation_time")
     private LocalDateTime creationTime;
 
     @Column(name = "dve_file_path", nullable = false)

--- a/src/main/java/nl/knaw/dans/ttv/db/TransferItem.java
+++ b/src/main/java/nl/knaw/dans/ttv/db/TransferItem.java
@@ -39,7 +39,6 @@ public class TransferItem {
     private static final Logger log = LoggerFactory.getLogger(TransferItem.class);
 
     public enum TransferStatus {
-        EXTRACT,
         COLLECTED,
         TARRING,
         OCFLTARCREATED,

--- a/src/test/java/nl/knaw/dans/ttv/core/CollectTaskManagerTest.java
+++ b/src/test/java/nl/knaw/dans/ttv/core/CollectTaskManagerTest.java
@@ -62,7 +62,7 @@ class CollectTaskManagerTest {
 
     @Test
     void createsInboxWatchersOnStart() {
-        var manager = new CollectTaskManager(inboxes, Path.of("data/collect-workdir"), Path.of("data/outbox/"), 100, executorService, transferItemService, transferItemMetadataReader, fileService,
+        var manager = new CollectTaskManager(inboxes, Path.of("data/outbox/"), 100, executorService, transferItemService, transferItemMetadataReader, fileService,
             inboxWatcherFactory);
 
         try {
@@ -87,7 +87,7 @@ class CollectTaskManagerTest {
 
     @Test
     void onZipFileAdded() {
-        var manager = new CollectTaskManager(inboxes, Path.of("data/collect-workdir"), Path.of("data/outbox/"), 150L, executorService, transferItemService, transferItemMetadataReader, fileService,
+        var manager = new CollectTaskManager(inboxes, Path.of("data/outbox/"), 150L, executorService, transferItemService, transferItemMetadataReader, fileService,
             inboxWatcherFactory);
         var file = Mockito.mock(File.class);
         Mockito.when(file.isFile()).thenReturn(true);
@@ -100,7 +100,7 @@ class CollectTaskManagerTest {
 
     @Test
     void onNonZipFileAdded() {
-        var manager = new CollectTaskManager(inboxes, Path.of("data/collect-workdir"), Path.of("data/outbox/"), 100L, executorService, transferItemService, transferItemMetadataReader, fileService,
+        var manager = new CollectTaskManager(inboxes, Path.of("data/outbox/"), 100L, executorService, transferItemService, transferItemMetadataReader, fileService,
             inboxWatcherFactory);
         var file = Mockito.mock(File.class);
         Mockito.when(file.isFile()).thenReturn(true);

--- a/src/test/java/nl/knaw/dans/ttv/core/CollectTaskManagerTest.java
+++ b/src/test/java/nl/knaw/dans/ttv/core/CollectTaskManagerTest.java
@@ -56,13 +56,14 @@ class CollectTaskManagerTest {
     private CollectConfiguration.InboxEntry createInboxEntry(String name, String value) {
         var entry = new CollectConfiguration.InboxEntry();
         entry.setName(name);
-        entry.setPath(value);
+        entry.setPath(Path.of(value));
         return entry;
     }
 
     @Test
     void createsInboxWatchersOnStart() {
-        var manager = new CollectTaskManager(inboxes, "data/outbox/", 100, executorService, transferItemService, transferItemMetadataReader, fileService, inboxWatcherFactory);
+        var manager = new CollectTaskManager(inboxes, Path.of("data/collect-workdir"), Path.of("data/outbox/"), 100, executorService, transferItemService, transferItemMetadataReader, fileService,
+            inboxWatcherFactory);
 
         try {
             manager.start();
@@ -86,7 +87,8 @@ class CollectTaskManagerTest {
 
     @Test
     void onZipFileAdded() {
-        var manager = new CollectTaskManager(inboxes, "data/outbox/", 150L, executorService, transferItemService, transferItemMetadataReader, fileService, inboxWatcherFactory);
+        var manager = new CollectTaskManager(inboxes, Path.of("data/collect-workdir"), Path.of("data/outbox/"), 150L, executorService, transferItemService, transferItemMetadataReader, fileService,
+            inboxWatcherFactory);
         var file = Mockito.mock(File.class);
         Mockito.when(file.isFile()).thenReturn(true);
         Mockito.when(file.getName()).thenReturn("some_file.zip");
@@ -98,7 +100,8 @@ class CollectTaskManagerTest {
 
     @Test
     void onNonZipFileAdded() {
-        var manager = new CollectTaskManager(inboxes, "data/outbox/", 100L, executorService, transferItemService, transferItemMetadataReader, fileService, inboxWatcherFactory);
+        var manager = new CollectTaskManager(inboxes, Path.of("data/collect-workdir"), Path.of("data/outbox/"), 100L, executorService, transferItemService, transferItemMetadataReader, fileService,
+            inboxWatcherFactory);
         var file = Mockito.mock(File.class);
         Mockito.when(file.isFile()).thenReturn(true);
         Mockito.when(file.getName()).thenReturn("some_file.exe");

--- a/src/test/java/nl/knaw/dans/ttv/core/MetadataTaskTest.java
+++ b/src/test/java/nl/knaw/dans/ttv/core/MetadataTaskTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2021 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.ttv.core;
+
+import nl.knaw.dans.ttv.core.service.FileService;
+import nl.knaw.dans.ttv.core.service.TransferItemMetadataReader;
+import nl.knaw.dans.ttv.core.service.TransferItemService;
+import nl.knaw.dans.ttv.db.TransferItem;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class MetadataTaskTest {
+
+    private TransferItemService transferItemService;
+    private TransferItemMetadataReader transferItemMetadataReader;
+    private FileService fileService;
+
+    @BeforeEach
+    void setUp() {
+        this.transferItemService = Mockito.mock(TransferItemService.class);
+        this.transferItemMetadataReader = Mockito.mock(TransferItemMetadataReader.class);
+        this.fileService = Mockito.mock(FileService.class);
+    }
+
+    @Test
+    void testAllFilesAreMoved() throws IOException {
+        var filePath = Path.of("data/inbox/doi-10-5072-dar-kxteqtv1.0.zip");
+        var outbox = Path.of("data/outbox");
+
+        var task = new MetadataTask(filePath, outbox, transferItemService, transferItemMetadataReader, fileService);
+
+        Mockito.when(transferItemService.getTransferItemByFilenameAttributes(Mockito.any()))
+            .thenReturn(Optional.of(new TransferItem("pid", 1, 0, "path", LocalDateTime.now(), TransferItem.TransferStatus.CREATED)));
+
+        task.run();
+
+        Mockito.verify(fileService).moveFile(filePath, Path.of("data/outbox/doi-10-5072-dar-kxteqtv1.0.zip"));
+    }
+
+    @Test
+    void testMetadataIsUpdated() {
+        var filePath = Path.of("data/inbox/doi-10-5072-dar-kxteqtv1.0.zip");
+        var outbox = Path.of("data/outbox");
+
+        var task = new MetadataTask(filePath, outbox, transferItemService, transferItemMetadataReader, fileService);
+        var transferItem = new TransferItem("pid", 1, 0, "path", LocalDateTime.now(), TransferItem.TransferStatus.CREATED);
+
+        Mockito.when(transferItemService.getTransferItemByFilenameAttributes(Mockito.any()))
+            .thenReturn(Optional.of(transferItem));
+
+        task.run();
+
+        Mockito.verify(transferItemService).addMetadataAndMoveFile(
+            Mockito.eq(transferItem),
+            Mockito.any(),
+            Mockito.any(),
+            Mockito.eq(TransferItem.TransferStatus.COLLECTED),
+            Mockito.eq(Path.of("data/outbox/doi-10-5072-dar-kxteqtv1.0.zip"))
+        );
+    }
+
+    @Test
+    void testCollectedStatusIsAlsoHandled() {
+        var filePath = Path.of("data/inbox/doi-10-5072-dar-kxteqtv1.0.zip");
+        var outbox = Path.of("data/outbox");
+
+        var task = new MetadataTask(filePath, outbox, transferItemService, transferItemMetadataReader, fileService);
+        var transferItem = new TransferItem("pid", 1, 0, "path", LocalDateTime.now(), TransferItem.TransferStatus.COLLECTED);
+
+        Mockito.when(transferItemService.getTransferItemByFilenameAttributes(Mockito.any()))
+            .thenReturn(Optional.of(transferItem));
+
+        task.run();
+
+        Mockito.verify(transferItemService).addMetadataAndMoveFile(
+            Mockito.eq(transferItem),
+            Mockito.any(),
+            Mockito.any(),
+            Mockito.eq(TransferItem.TransferStatus.COLLECTED),
+            Mockito.eq(Path.of("data/outbox/doi-10-5072-dar-kxteqtv1.0.zip"))
+        );
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = TransferItem.TransferStatus.class, mode = EnumSource.Mode.EXCLUDE, names = { "COLLECTED", "CREATED" })
+    void testInvalidStates(TransferItem.TransferStatus status) {
+        var filePath = Path.of("data/inbox/doi-10-5072-dar-kxteqtv1.0.zip");
+        var outbox = Path.of("data/outbox");
+
+        var task = new MetadataTask(filePath, outbox, transferItemService, transferItemMetadataReader, fileService);
+        var transferItem = new TransferItem("pid", 1, 0, "path", LocalDateTime.now(), status);
+
+        Mockito.when(transferItemService.getTransferItemByFilenameAttributes(Mockito.any()))
+            .thenReturn(Optional.of(transferItem));
+
+        assertThrows(InvalidTransferItemException.class, () -> {
+            task.processFile(filePath);
+        });
+    }
+}

--- a/src/test/java/nl/knaw/dans/ttv/core/TarTaskManagerTest.java
+++ b/src/test/java/nl/knaw/dans/ttv/core/TarTaskManagerTest.java
@@ -67,7 +67,7 @@ class TarTaskManagerTest {
     @Test
     void onNewItemInInbox() {
         var manager = new TarTaskManager(
-            "data/inbox", "data/workdir", 50, "dmf", "tst@account.com:", 100L,
+            Path.of("data/inbox"), Path.of("data/workdir"), 50, "dmf", "tst@account.com:", 100L,
             executorService, inboxWatcherFactory, fileService, ocflRepositoryService, transferItemService,
             tarCommandRunner);
 
@@ -113,7 +113,7 @@ class TarTaskManagerTest {
     @Test
     void testThresholdIsNotReached() {
         var manager = new TarTaskManager(
-            "data/inbox", "data/workdir", 50, "dmf", "tst@account.com:", 100L,
+            Path.of("data/inbox"), Path.of("data/workdir"), 50, "dmf", "tst@account.com:", 100L,
             executorService, inboxWatcherFactory, fileService, ocflRepositoryService, transferItemService,
             tarCommandRunner);
 

--- a/src/test/java/nl/knaw/dans/ttv/core/config/validation/UniqueInboxEntryNamesValidatorTest.java
+++ b/src/test/java/nl/knaw/dans/ttv/core/config/validation/UniqueInboxEntryNamesValidatorTest.java
@@ -18,6 +18,7 @@ package nl.knaw.dans.ttv.core.config.validation;
 import nl.knaw.dans.ttv.core.config.CollectConfiguration;
 import org.junit.jupiter.api.Test;
 
+import java.nio.file.Path;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -29,9 +30,9 @@ class UniqueInboxEntryNamesValidatorTest {
     void testIsValid() {
         var validator = new UniqueInboxEntryNamesValidator();
         var entries = List.of(
-            new CollectConfiguration.InboxEntry("name1", "tmp/folder1"),
-            new CollectConfiguration.InboxEntry("name2", "tmp/folder2"),
-            new CollectConfiguration.InboxEntry("name3", "tmp/folder3")
+            new CollectConfiguration.InboxEntry("name1", Path.of("tmp/folder1")),
+            new CollectConfiguration.InboxEntry("name2", Path.of("tmp/folder2")),
+            new CollectConfiguration.InboxEntry("name3", Path.of("tmp/folder3"))
         );
 
         var result = validator.isValid(entries, null);
@@ -43,9 +44,9 @@ class UniqueInboxEntryNamesValidatorTest {
     void testIsInValid() {
         var validator = new UniqueInboxEntryNamesValidator();
         var entries = List.of(
-            new CollectConfiguration.InboxEntry("name1", "tmp/folder1"),
-            new CollectConfiguration.InboxEntry("name2", "tmp/folder2"),
-            new CollectConfiguration.InboxEntry("name1", "tmp/folder3")
+            new CollectConfiguration.InboxEntry("name1", Path.of("tmp/folder1")),
+            new CollectConfiguration.InboxEntry("name2", Path.of("tmp/folder2")),
+            new CollectConfiguration.InboxEntry("name1", Path.of("tmp/folder3"))
         );
 
         var result = validator.isValid(entries, null);
@@ -60,9 +61,9 @@ class UniqueInboxEntryNamesValidatorTest {
     void testIsValidDespiteDuplicatePaths() {
         var validator = new UniqueInboxEntryNamesValidator();
         var entries = List.of(
-            new CollectConfiguration.InboxEntry("name1", "tmp/folder"),
-            new CollectConfiguration.InboxEntry("name2", "tmp/folder"),
-            new CollectConfiguration.InboxEntry("name3", "tmp/folder")
+            new CollectConfiguration.InboxEntry("name1", Path.of("tmp/folder")),
+            new CollectConfiguration.InboxEntry("name2", Path.of("tmp/folder")),
+            new CollectConfiguration.InboxEntry("name3", Path.of("tmp/folder"))
         );
 
         var result = validator.isValid(entries, null);

--- a/src/test/java/nl/knaw/dans/ttv/core/config/validation/UniqueInboxEntryPathsValidatorTest.java
+++ b/src/test/java/nl/knaw/dans/ttv/core/config/validation/UniqueInboxEntryPathsValidatorTest.java
@@ -18,6 +18,7 @@ package nl.knaw.dans.ttv.core.config.validation;
 import nl.knaw.dans.ttv.core.config.CollectConfiguration;
 import org.junit.jupiter.api.Test;
 
+import java.nio.file.Path;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -29,9 +30,9 @@ class UniqueInboxEntryPathsValidatorTest {
     void testIsValid() {
         var validator = new UniqueInboxEntryPathsValidator();
         var entries = List.of(
-            new CollectConfiguration.InboxEntry("name1", "tmp/folder1"),
-            new CollectConfiguration.InboxEntry("name2", "tmp/folder2"),
-            new CollectConfiguration.InboxEntry("name3", "tmp/folder3")
+            new CollectConfiguration.InboxEntry("name1", Path.of("tmp/folder1")),
+            new CollectConfiguration.InboxEntry("name2", Path.of("tmp/folder2")),
+            new CollectConfiguration.InboxEntry("name3", Path.of("tmp/folder3"))
         );
 
         var result = validator.isValid(entries, null);
@@ -43,9 +44,9 @@ class UniqueInboxEntryPathsValidatorTest {
     void testIsInValid() {
         var validator = new UniqueInboxEntryPathsValidator();
         var entries = List.of(
-            new CollectConfiguration.InboxEntry("name1", "tmp/folder1"),
-            new CollectConfiguration.InboxEntry("name2", "tmp/folder2"),
-            new CollectConfiguration.InboxEntry("name3", "tmp/folder1")
+            new CollectConfiguration.InboxEntry("name1", Path.of("tmp/folder1")),
+            new CollectConfiguration.InboxEntry("name2", Path.of("tmp/folder2")),
+            new CollectConfiguration.InboxEntry("name3", Path.of("tmp/folder1"))
         );
 
         var result = validator.isValid(entries, null);
@@ -60,9 +61,9 @@ class UniqueInboxEntryPathsValidatorTest {
     void testIsValidDespiteDuplicateNames() {
         var validator = new UniqueInboxEntryPathsValidator();
         var entries = List.of(
-            new CollectConfiguration.InboxEntry("name", "tmp/folder1"),
-            new CollectConfiguration.InboxEntry("name", "tmp/folder2"),
-            new CollectConfiguration.InboxEntry("name", "tmp/folder3")
+            new CollectConfiguration.InboxEntry("name", Path.of("tmp/folder1")),
+            new CollectConfiguration.InboxEntry("name", Path.of("tmp/folder2")),
+            new CollectConfiguration.InboxEntry("name", Path.of("tmp/folder3"))
         );
 
         var result = validator.isValid(entries, null);

--- a/src/test/java/nl/knaw/dans/ttv/core/service/TransferItemServiceImplTest.java
+++ b/src/test/java/nl/knaw/dans/ttv/core/service/TransferItemServiceImplTest.java
@@ -78,7 +78,7 @@ class TransferItemServiceImplTest {
         try {
             var transferItem = transferItemService.createTransferItem("datastation name", filenameAttributes, filesystemAttributes, fileContentAttributes);
 
-            Assertions.assertEquals(TransferItem.TransferStatus.EXTRACT, transferItem.getTransferStatus());
+            Assertions.assertEquals(TransferItem.TransferStatus.COLLECTED, transferItem.getTransferStatus());
             assertNotNull(transferItem.getQueueDate());
             assertEquals("datastation name", transferItem.getDatasetDvInstance());
 

--- a/src/test/java/nl/knaw/dans/ttv/db/TransferItemDAOTest.java
+++ b/src/test/java/nl/knaw/dans/ttv/db/TransferItemDAOTest.java
@@ -50,14 +50,14 @@ class TransferItemDAOTest {
     void createTransferItem() {
         final TransferItem dataset = daoTestRule.inTransaction(() -> transferItemDAO.save(
             new TransferItem("doi:10.5072/FK2/P4PHV7", 1, 0, "src/test/resources/doi-10-5072-fk2-p4phv7v-1-0/metadata/oai-ore.jsonld", LocalDateTime.parse("2007-12-03T10:15:30"),
-                TransferItem.TransferStatus.EXTRACT)));
+                TransferItem.TransferStatus.COLLECTED)));
         assertThat(dataset.getId()).isPositive();
         assertThat(dataset.getDatasetPid()).isEqualTo("doi:10.5072/FK2/P4PHV7");
         assertThat(dataset.getVersionMajor()).isEqualTo(1);
         assertThat(dataset.getVersionMinor()).isEqualTo(0);
         assertThat(dataset.getDveFilePath()).isEqualTo("src/test/resources/doi-10-5072-fk2-p4phv7v-1-0/metadata/oai-ore.jsonld");
         assertThat(dataset.getCreationTime()).isEqualTo(LocalDateTime.parse("2007-12-03T10:15:30"));
-        assertThat(dataset.getTransferStatus()).isEqualTo(TransferItem.TransferStatus.EXTRACT);
+        assertThat(dataset.getTransferStatus()).isEqualTo(TransferItem.TransferStatus.COLLECTED);
         assertThat(transferItemDAO.findById(dataset.getId())).isEqualTo(Optional.of(dataset));
     }
 
@@ -65,7 +65,7 @@ class TransferItemDAOTest {
     void findAll() {
         daoTestRule.inTransaction(() -> {
             transferItemDAO.save(new TransferItem("doi:10.5072/FK2/P4PHV7", 1, 0, "src/test/resources/doi-10-5072-fk2-p4phv7v-1-0/metadata/oai-ore.jsonld", LocalDateTime.parse("2007-12-03T10:15:30"),
-                TransferItem.TransferStatus.EXTRACT));
+                TransferItem.TransferStatus.COLLECTED));
             transferItemDAO.save(new TransferItem("doi:10.5072/FK2/JOY8UU", 2, 0, "src/test/resources/doi-10-5072-fk2-joy8uuv-2-0/metadata/oai-ore.jsonld", LocalDateTime.parse("2008-12-03T11:30:00"),
                 TransferItem.TransferStatus.COLLECTED));
             transferItemDAO.save(new TransferItem("doi:10.5072/FK2/QZ0LJQ", 1, 2, "src/test/resources/doi-10-5072-fk2-qz0ljqv-1-2/metadata/oai-ore.jsonld", LocalDateTime.parse("2020-08-03T00:15:22"),
@@ -81,7 +81,7 @@ class TransferItemDAOTest {
                 "src/test/resources/doi-10-5072-fk2-qz0ljqv-1-2/metadata/oai-ore.jsonld");
         assertThat(transferItems).extracting("creationTime")
             .containsOnly(LocalDateTime.parse("2007-12-03T10:15:30"), LocalDateTime.parse("2008-12-03T11:30:00"), LocalDateTime.parse("2020-08-03T00:15:22"));
-        assertThat(transferItems).extracting("transferStatus").containsOnly(TransferItem.TransferStatus.EXTRACT, TransferItem.TransferStatus.COLLECTED, TransferItem.TransferStatus.TARRING);
+        assertThat(transferItems).extracting("transferStatus").containsOnly(TransferItem.TransferStatus.COLLECTED, TransferItem.TransferStatus.TARRING);
     }
 
     @Test
@@ -89,7 +89,7 @@ class TransferItemDAOTest {
         assertThatExceptionOfType(ConstraintViolationException.class).isThrownBy(() ->
             daoTestRule.inTransaction(() -> transferItemDAO.save(
                 new TransferItem(null, 1, 0, "src/test/resources/doi-10-5072-fk2-p4phv7v-1-0/metadata/oai-ore.jsonld", LocalDateTime.parse("2020-08-03T00:15:22"),
-                    TransferItem.TransferStatus.EXTRACT))));
+                    TransferItem.TransferStatus.COLLECTED))));
     }
 
     @Test
@@ -167,7 +167,7 @@ class TransferItemDAOTest {
     void findByDatasetPidAndVersion() {
         daoTestRule.inTransaction(() -> {
             transferItemDAO.save(new TransferItem("doi:10.5072/FK2/P4PHV7", 1, 0, "src/test/resources/doi-10-5072-fk2-p4phv7v-1-0/metadata/oai-ore.jsonld", LocalDateTime.parse("2007-12-03T10:15:30"),
-                TransferItem.TransferStatus.EXTRACT));
+                TransferItem.TransferStatus.COLLECTED));
             transferItemDAO.save(new TransferItem("doi:10.5072/FK2/JOY8UU", 2, 0, "src/test/resources/doi-10-5072-fk2-joy8uuv-2-0/metadata/oai-ore.jsonld", LocalDateTime.parse("2008-12-03T11:30:00"),
                 TransferItem.TransferStatus.COLLECTED));
             transferItemDAO.save(new TransferItem("doi:10.5072/FK2/QZ0LJQ", 1, 2, "src/test/resources/doi-10-5072-fk2-qz0ljqv-1-2/metadata/oai-ore.jsonld", LocalDateTime.parse("2020-08-03T00:15:22"),


### PR DESCRIPTION
Fixes DD-826

# Description of changes
Adds an intermediate workdir for the collect step to mitigate possible timing issues with copy-delete actions from the network file shares to the local disks.

# How to test


# Related PRs
(Add links)
*

# Notify
@DANS-KNAW/dataversedans
