### PR TITLE
Add startup verification checks

### DIFF
--- a/src/main/java/nl/knaw/dans/ttv/core/ConfirmArchivedTaskCreator.java
+++ b/src/main/java/nl/knaw/dans/ttv/core/ConfirmArchivedTaskCreator.java
@@ -31,7 +31,7 @@ public class ConfirmArchivedTaskCreator implements Job {
     private static final Logger log = LoggerFactory.getLogger(ConfirmArchivedTaskCreator.class);
 
     @Override
-    public void execute(JobExecutionContext context) throws JobExecutionException {
+    public void execute(JobExecutionContext context) {
         var dataMap = context.getMergedJobDataMap();
         var transferItemService = (TransferItemService) dataMap.get("transferItemService");
         var workingDir = (Path) dataMap.get("workingDir");
@@ -43,7 +43,7 @@ public class ConfirmArchivedTaskCreator implements Job {
 
         for (var tar: tars) {
             var task = new ConfirmArchivedTask(tar, transferItemService, archiveStatusService, ocflRepositoryService, workingDir);
-            log.debug("executing task {}", task);
+            log.debug("Executing task {}", task);
             executorService.execute(task);
         }
     }

--- a/src/main/java/nl/knaw/dans/ttv/core/ConfirmArchivedTaskManager.java
+++ b/src/main/java/nl/knaw/dans/ttv/core/ConfirmArchivedTaskManager.java
@@ -62,8 +62,8 @@ public class ConfirmArchivedTaskManager implements Managed {
         log.info("Verifying archive status");
         verifyArchives();
 
-        SchedulerFactory sf = new StdSchedulerFactory();
-        this.scheduler = sf.getScheduler();
+        var schedulerFactory = new StdSchedulerFactory();
+        this.scheduler = schedulerFactory.getScheduler();
 
         var jobData = new JobDataMap();
 
@@ -75,12 +75,12 @@ public class ConfirmArchivedTaskManager implements Managed {
         jobData.put("archiveStatusService", archiveStatusService);
         jobData.put("ocflRepositoryService", ocflRepositoryService);
 
-        JobDetail job = JobBuilder.newJob(ConfirmArchivedTaskCreator.class)
+        var job = JobBuilder.newJob(ConfirmArchivedTaskCreator.class)
             .withIdentity("job", "group")
             .setJobData(jobData)
             .build();
 
-        CronTrigger trigger = TriggerBuilder.newTrigger()
+        var trigger = TriggerBuilder.newTrigger()
             .withIdentity("trigger", "group")
             .withSchedule(CronScheduleBuilder.cronSchedule(this.schedule))
             .build();

--- a/src/main/java/nl/knaw/dans/ttv/core/MetadataTask.java
+++ b/src/main/java/nl/knaw/dans/ttv/core/MetadataTask.java
@@ -49,8 +49,14 @@ public class MetadataTask implements Runnable {
             processFile(this.filePath);
         }
         catch (IOException | InvalidTransferItemException e) {
-            log.error("unable to create TransferItem for path '{}'", this.filePath, e);
-            // TODO move to deadletter box
+            log.error("Unable to create TransferItem for path '{}'", this.filePath, e);
+
+            try {
+                fileService.rejectFile(this.filePath, e);
+            }
+            catch (IOException ex) {
+                log.error("Unable to reject file", ex);
+            }
         }
     }
 

--- a/src/main/java/nl/knaw/dans/ttv/core/service/OcflRepositoryService.java
+++ b/src/main/java/nl/knaw/dans/ttv/core/service/OcflRepositoryService.java
@@ -25,7 +25,11 @@ public interface OcflRepositoryService {
 
     OcflRepository createRepository(Path path, String id) throws IOException;
 
+    OcflRepository openRepository(Path path, String id);
+
     String importTransferItem(OcflRepository ocflRepository, TransferItem transferItem);
+
+    String getObjectIdForTransferItem(TransferItem transferItem);
 
     void closeOcflRepository(OcflRepository ocflRepository);
 

--- a/src/main/java/nl/knaw/dans/ttv/core/service/TarCommandRunner.java
+++ b/src/main/java/nl/knaw/dans/ttv/core/service/TarCommandRunner.java
@@ -26,4 +26,5 @@ public interface TarCommandRunner {
 
     ProcessResult verifyPackage(String targetPackage) throws IOException, InterruptedException;
 
+    ProcessResult deletePackage(String targetPackage) throws IOException, InterruptedException;
 }

--- a/src/main/java/nl/knaw/dans/ttv/core/service/TarCommandRunnerImpl.java
+++ b/src/main/java/nl/knaw/dans/ttv/core/service/TarCommandRunnerImpl.java
@@ -65,6 +65,21 @@ public class TarCommandRunnerImpl implements TarCommandRunner {
         return processRunner.run(command);
     }
 
+    @Override
+    public ProcessResult deletePackage(String path) throws IOException, InterruptedException {
+        var remotePath = Path.of(dataArchiveConfiguration.getPath(), path);
+        var command = new String[] {
+            "ssh",
+            getSshHost(),
+            "dmftar",
+            "--delete-archive",
+            "-f",
+            remotePath.toString()
+        };
+
+        return processRunner.run(command);
+    }
+
     private String getSshHost() {
         return String.format("%s@%s", this.dataArchiveConfiguration.getUser(), this.dataArchiveConfiguration.getHost());
     }

--- a/src/main/java/nl/knaw/dans/ttv/core/service/TransferItemService.java
+++ b/src/main/java/nl/knaw/dans/ttv/core/service/TransferItemService.java
@@ -57,4 +57,9 @@ public interface TransferItemService {
     void resetTarToArchiving(Tar tar);
 
     void updateTarToArchived(Tar tar);
+
+    List<Tar> findTarsByStatusTarring();
+
+    List<Tar> findTarsByConfirmInProgress();
+
 }

--- a/src/main/java/nl/knaw/dans/ttv/db/Tar.java
+++ b/src/main/java/nl/knaw/dans/ttv/db/Tar.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.ttv.db;
 
+import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.ColumnDefault;
 
 import javax.persistence.CascadeType;
@@ -22,6 +23,7 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
@@ -49,7 +51,7 @@ public class Tar {
     @Enumerated(EnumType.STRING)
     @Column(name = "tar_status")
     private TarStatus tarStatus;
-    @OneToMany(mappedBy = "tar", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "tar", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<TarPart> tarParts = new ArrayList<>();
 
     public Tar(String tarUuid, TarStatus status, boolean confirmCheckInProgress) {
@@ -133,6 +135,19 @@ public class Tar {
     public enum TarStatus {
         TARRING,
         OCFLTARCREATED,
-        CONFIRMEDARCHIVED
+        OCFLTARFAILED,
+        CONFIRMEDARCHIVED,
+    }
+
+    @Override
+    public String toString() {
+        return "Tar{" +
+            "tarUuid='" + tarUuid + '\'' +
+            ", vaultPath='" + vaultPath + '\'' +
+            ", created=" + created +
+            ", datetimeConfirmedArchived=" + datetimeConfirmedArchived +
+            ", confirmCheckInProgress=" + confirmCheckInProgress +
+            ", tarStatus=" + tarStatus +
+            '}';
     }
 }

--- a/src/main/java/nl/knaw/dans/ttv/db/TarDAO.java
+++ b/src/main/java/nl/knaw/dans/ttv/db/TarDAO.java
@@ -16,6 +16,7 @@
 package nl.knaw.dans.ttv.db;
 
 import io.dropwizard.hibernate.AbstractDAO;
+import org.hibernate.Hibernate;
 import org.hibernate.SessionFactory;
 
 import java.util.List;
@@ -29,6 +30,13 @@ public class TarDAO extends AbstractDAO<Tar> {
 
     public Optional<Tar> findById(String id) {
         return Optional.ofNullable(get(id));
+    }
+
+    public List<TarPart> findAllParts() {
+        var query = currentSession().createQuery(
+            "from TarPart", TarPart.class);
+
+        return query.list();
     }
 
     public List<Tar> findAllTarsToBeConfirmed() {
@@ -46,4 +54,31 @@ public class TarDAO extends AbstractDAO<Tar> {
         return persist(tar);
     }
 
+    public List<Tar> findByStatus(Tar.TarStatus status) {
+        var query = currentSession().createQuery(
+            "from Tar where tarStatus = :status", Tar.class);
+
+        query.setParameter("status", status);
+
+        return query.list();
+    }
+
+    public Tar saveWithParts(Tar tar, List<TarPart> parts) {
+        Hibernate.initialize(tar.getTarParts());
+        tar.getTarParts().clear();
+        tar.getTarParts().addAll(parts);
+
+        return save(tar);
+    }
+
+    public void evict(Tar tar) {
+        currentSession().evict(tar);
+    }
+
+    public List<Tar> findTarsByConfirmInProgress() {
+        var query = currentSession().createQuery(
+            "from Tar where confirmCheckInProgress = true", Tar.class);
+
+        return query.list();
+    }
 }

--- a/src/main/java/nl/knaw/dans/ttv/db/TarPart.java
+++ b/src/main/java/nl/knaw/dans/ttv/db/TarPart.java
@@ -41,6 +41,17 @@ public class TarPart {
     @JoinColumn(name = "tar_id")
     private Tar tar;
 
+    public TarPart(String partName, String checksumAlgorithm, String checksumValue, Tar tar) {
+        this.partName = partName;
+        this.checksumAlgorithm = checksumAlgorithm;
+        this.checksumValue = checksumValue;
+        this.tar = tar;
+    }
+
+    public TarPart() {
+
+    }
+
     public long getId() {
         return id;
     }

--- a/src/test/java/nl/knaw/dans/ttv/core/ConfirmArchivedTaskTest.java
+++ b/src/test/java/nl/knaw/dans/ttv/core/ConfirmArchivedTaskTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2021 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.ttv.core;
+
+import nl.knaw.dans.ttv.core.service.ArchiveStatusService;
+import nl.knaw.dans.ttv.core.service.OcflRepositoryService;
+import nl.knaw.dans.ttv.core.service.TransferItemService;
+import nl.knaw.dans.ttv.db.Tar;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Map;
+
+class ConfirmArchivedTaskTest {
+
+    private TransferItemService transferItemService;
+    private ArchiveStatusService archiveStatusService;
+    private OcflRepositoryService ocflRepositoryService;
+
+    @BeforeEach
+    void setUp() {
+        this.transferItemService = Mockito.mock(TransferItemService.class);
+        this.archiveStatusService = Mockito.mock(ArchiveStatusService.class);
+        this.ocflRepositoryService = Mockito.mock(OcflRepositoryService.class);
+    }
+
+    @Test
+    void testCompletelyArchived() throws IOException, InterruptedException {
+        var tar = new Tar("test1", Tar.TarStatus.OCFLTARCREATED, false);
+        var path = Path.of("workingdir");
+        var task = new ConfirmArchivedTask(tar, transferItemService, archiveStatusService, ocflRepositoryService, path);
+
+        var fileStatus = Map.of(
+            "file1", ArchiveStatusService.FileStatus.DUAL,
+            "file2", ArchiveStatusService.FileStatus.OFFLINE
+        );
+
+        Mockito.when(archiveStatusService.getFileStatus("test1"))
+            .thenReturn(fileStatus);
+
+        task.run();
+
+        Mockito.verify(transferItemService).updateTarToArchived(Mockito.any());
+        Mockito.verify(ocflRepositoryService).cleanupRepository(Mockito.any(), Mockito.any());
+    }
+
+    @Test
+    void testPartiallyArchived() throws IOException, InterruptedException {
+        var tar = new Tar("test1", Tar.TarStatus.OCFLTARCREATED, false);
+        var path = Path.of("workingdir");
+        var task = new ConfirmArchivedTask(tar, transferItemService, archiveStatusService, ocflRepositoryService, path);
+
+        var fileStatus = Map.of(
+            "file1", ArchiveStatusService.FileStatus.DUAL,
+            "file2", ArchiveStatusService.FileStatus.REGULAR
+        );
+
+        Mockito.when(archiveStatusService.getFileStatus("test1"))
+            .thenReturn(fileStatus);
+
+        task.run();
+
+        Mockito.verify(transferItemService).resetTarToArchiving(Mockito.any());
+        Mockito.verify(ocflRepositoryService, Mockito.times(0))
+            .cleanupRepository(Mockito.any(), Mockito.any());
+    }
+
+    @Test
+    void testOnError() throws IOException, InterruptedException {
+        var tar = new Tar("test1", Tar.TarStatus.OCFLTARCREATED, false);
+        var path = Path.of("workingdir");
+        var task = new ConfirmArchivedTask(tar, transferItemService, archiveStatusService, ocflRepositoryService, path);
+
+        var fileStatus = Map.of(
+            "file1", ArchiveStatusService.FileStatus.DUAL,
+            "file2", ArchiveStatusService.FileStatus.REGULAR
+        );
+
+        Mockito.when(archiveStatusService.getFileStatus("test1"))
+            .thenThrow(IOException.class);
+
+        task.run();
+
+        Mockito.verify(transferItemService).resetTarToArchiving(Mockito.any());
+        Mockito.verify(ocflRepositoryService, Mockito.times(0))
+            .cleanupRepository(Mockito.any(), Mockito.any());
+    }
+
+    @Test
+    void testOnCleanupErrorShouldNotThrowErrors() throws IOException, InterruptedException {
+        var tar = new Tar("test1", Tar.TarStatus.OCFLTARCREATED, false);
+        var path = Path.of("workingdir");
+        var task = new ConfirmArchivedTask(tar, transferItemService, archiveStatusService, ocflRepositoryService, path);
+
+        var fileStatus = Map.of(
+            "file1", ArchiveStatusService.FileStatus.DUAL,
+            "file2", ArchiveStatusService.FileStatus.OFFLINE
+        );
+
+        Mockito.when(archiveStatusService.getFileStatus("test1"))
+            .thenReturn(fileStatus);
+
+        Mockito.doThrow(IOException.class)
+            .when(ocflRepositoryService).cleanupRepository(Mockito.any(), Mockito.any());
+
+        task.run();
+
+        Mockito.verify(ocflRepositoryService).cleanupRepository(Mockito.any(), Mockito.any());
+    }
+}

--- a/src/test/java/nl/knaw/dans/ttv/core/service/TransferItemServiceImplTest.java
+++ b/src/test/java/nl/knaw/dans/ttv/core/service/TransferItemServiceImplTest.java
@@ -210,9 +210,8 @@ class TransferItemServiceImplTest {
         assertEquals(Tar.TarStatus.OCFLTARCREATED, tar.getTarStatus());
         // TODO determine the correct status
         assertEquals(TransferItem.TransferStatus.OCFLTARCREATED, transferItem.getTransferStatus());
-        assertEquals("ident", tar.getTarParts().get(0).getPartName());
-        assertEquals("md5", tar.getTarParts().get(0).getChecksumAlgorithm());
-        assertEquals("check", tar.getTarParts().get(0).getChecksumValue());
+
+        Mockito.verify(tarDAO).saveWithParts(Mockito.any(), Mockito.any());
     }
 
     @Test


### PR DESCRIPTION
Fixes DD-824

# Description of changes

Adds verification procedures on startup, checking the state of the filesystem versus the database and trying to fix it whenever possible.

# How to test


# Related PRs
(Add links)
*

# Notify
@DANS-KNAW/dataversedans
