### PR TITLE
NO JIRA. Some improvements to health check readability + corrected port numbers

### DIFF
--- a/src/main/assembly/dist/bin/dd-transfer-to-vault
+++ b/src/main/assembly/dist/bin/dd-transfer-to-vault
@@ -4,4 +4,4 @@ SCRIPTNAME=$(basename $0)
 BINPATH=$(command readlink -f $0 2> /dev/null || command grealpath $0 2> /dev/null)
 APPHOME=$(dirname  $(dirname $BINPATH))
 
-java -jar $APPHOME/bin/$SCRIPTNAME.jar "$@"
+java $DANS_JAVA_OPTS -jar $APPHOME/bin/$SCRIPTNAME.jar "$@"

--- a/src/main/assembly/dist/cfg/config.yml
+++ b/src/main/assembly/dist/cfg/config.yml
@@ -1,3 +1,13 @@
+server:
+  applicationContextPath: /
+  adminContextPath: /
+  applicationConnectors:
+    - type: http
+      port: 20350
+  adminConnectors:
+    - type: http
+      port: 20351
+
 health:
   delayedShutdownHandlerEnabled: false
   initialOverallState: false

--- a/src/main/java/nl/knaw/dans/ttv/core/service/FileServiceImpl.java
+++ b/src/main/java/nl/knaw/dans/ttv/core/service/FileServiceImpl.java
@@ -236,5 +236,4 @@ public class FileServiceImpl implements FileService {
 
         return zipFile.getInputStream(entryPath);
     }
-
 }

--- a/src/main/java/nl/knaw/dans/ttv/health/RemoteDmftarHealthCheck.java
+++ b/src/main/java/nl/knaw/dans/ttv/health/RemoteDmftarHealthCheck.java
@@ -39,6 +39,7 @@ public class RemoteDmftarHealthCheck extends HealthCheck {
     protected Result check() throws Exception {
         log.debug("Checking if dmftar is available remotely");
         var healthy = true;
+        var reason = "";
 
         try {
             var result = tarCommandRunner.getDmftarVersion();
@@ -46,6 +47,7 @@ public class RemoteDmftarHealthCheck extends HealthCheck {
             if (result.getStatusCode() != 0) {
                 log.error("Return code for command 'dmftar --version' is {}, expected 0", result.getStatusCode());
                 healthy = false;
+                reason = "Return code for command 'dmftar --version' is " + result.getStatusCode() + ", expected 0";
             }
             else {
                 // do the version check
@@ -63,24 +65,27 @@ public class RemoteDmftarHealthCheck extends HealthCheck {
                         log.error("Remote dmftar version is incorrect, installed version is {}, expected {}",
                             version, expected);
                         healthy = false;
+                        reason = "Remote dmftar version is incorrect, installed version is " + version + ", expected " + expected;
                     }
                 }
                 catch (RuntimeException e) {
                     log.error("Unable to parse dmftar output", e);
                     healthy = false;
+                    reason = "Unable to parse dmftar output";
                 }
             }
         }
         catch (IOException | InterruptedException e) {
             log.error("Unable to run dmftar --version", e);
             healthy = false;
+            reason = "Unable to run dmftar --version";
         }
 
         if (healthy) {
             return Result.healthy();
         }
         else {
-            return Result.unhealthy("Command dmftar is not working as expected, or the version is incorrect");
+            return Result.unhealthy("Command dmftar is not working as expected: " + reason);
         }
     }
 }


### PR DESCRIPTION
NO JIRA

# Description of changes
* Added support for remote debugging via the `DANS_JAVA_OPT` environment variable in the startup script.
* Added config for the http endpoints, including correct port numbers.
* Made the health check message more verbose.


# Notify

@DANS-KNAW/dataversedans
