### PR TITLE
Fixed function that reads file from ZIPped bag

### DIFF
--- a/src/main/java/nl/knaw/dans/ttv/core/service/DataFileAttributesReader.java
+++ b/src/main/java/nl/knaw/dans/ttv/core/service/DataFileAttributesReader.java
@@ -36,8 +36,8 @@ public class DataFileAttributesReader {
 
     public List<DataFileAttributes> readDataFileAttributes(Path dveZip) throws IOException {
         try (var datasetVersionExport = fileService.openZipFile(dveZip)) {
-            var pidMappingContent = fileService.openFileFromZip(datasetVersionExport, Path.of("metadata/pid-mapping.txt"));
-            var sha1ManifestContent = fileService.openFileFromZip(datasetVersionExport, Path.of("manifest-sha1.txt"));
+            var pidMappingContent = fileService.getEntryUnderBaseFolder(datasetVersionExport, Path.of("metadata/pid-mapping.txt"));
+            var sha1ManifestContent = fileService.getEntryUnderBaseFolder(datasetVersionExport, Path.of("manifest-sha1.txt"));
             var pidMapping = IOUtils.toString(pidMappingContent, StandardCharsets.UTF_8);
             var sha1Manifest = IOUtils.toString(sha1ManifestContent, StandardCharsets.UTF_8);
             var pathToPidMap = readPathToPidMapping(pidMapping);

--- a/src/main/java/nl/knaw/dans/ttv/core/service/FileService.java
+++ b/src/main/java/nl/knaw/dans/ttv/core/service/FileService.java
@@ -37,7 +37,17 @@ public interface FileService {
 
     ZipFile openZipFile(Path path) throws IOException;
 
-    InputStream openFileFromZip(ZipFile datasetVersionExport, Path of) throws IOException;
+    /**
+     * Returns an input stream for the entry under the base folder of the given zip file. The ZIP file is assumed to contain
+     * a single folder at the root level, and the entry is assumed to be under that folder.
+     *
+     * @param datasetVersionExport the zip file
+     * @param subpath              the path of the entry under the base folder
+     * @return an input stream for the entry
+     * @throws IOException              if the entry cannot be read
+     * @throws IllegalArgumentException if the entry is not found or if more than one base folder is found
+     */
+    InputStream getEntryUnderBaseFolder(ZipFile datasetVersionExport, Path subpath) throws IOException;
 
     Path moveFileAtomically(Path filePath, Path newPath) throws IOException;
 
@@ -56,5 +66,6 @@ public interface FileService {
     FileStore getFileStore(Path path) throws IOException;
 
     Path addCreationTimeToFileName(Path path) throws IOException;
+
     void cleanup(Path dir, Pattern pattern) throws IOException;
 }

--- a/src/main/java/nl/knaw/dans/ttv/core/service/TransferItemMetadataReaderImpl.java
+++ b/src/main/java/nl/knaw/dans/ttv/core/service/TransferItemMetadataReaderImpl.java
@@ -73,7 +73,7 @@ public class TransferItemMetadataReaderImpl implements TransferItemMetadataReade
         try {
             var datasetVersionExport = fileService.openZipFile(path);
 
-            var metadataContent = fileService.openFileFromZip(datasetVersionExport, Path.of("metadata/oai-ore.jsonld"));
+            var metadataContent = fileService.getEntryUnderBaseFolder(datasetVersionExport, Path.of("metadata/oai-ore.jsonld"));
             var oaiOre = IOUtils.toString(metadataContent, StandardCharsets.UTF_8);
             var fileContentAttributes = oaiOreMetadataReader.readMetadata(oaiOre);
             fileContentAttributes.setMetadata(oaiOre);


### PR DESCRIPTION
NO JIRA.

# Description of changes
The function `FileService.openFileFromZip` (now renamed to `getEntryUnderBaseFolder`) tried to open an zip entry by its path relative to the bag's root folder by just checking if the entry path ended in the requested path. This is wrong for several reasons, but where it failed was that `tagmanifest-sha1.txt` was read where `manifest-sha1.txt` was actually intended. Of course both end in the same string.

Fixed this by making the function name say more explicitly what it does and by exactly ignoring only the top level directory. If there are multiple top level dirs an exception is thrown.

# Notify

@DANS-KNAW/core-systems
