### PR TITLE
DD-2249 clean up version directory in work, if only half-unzipped

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,4 +17,4 @@ jobs:
       - name: Run tests and collect coverage
         run: mvn -B test
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6

--- a/src/main/java/nl/knaw/dans/transfer/core/SendToVaultTask.java
+++ b/src/main/java/nl/knaw/dans/transfer/core/SendToVaultTask.java
@@ -131,7 +131,8 @@ public class SendToVaultTask extends SourceDirItemProcessor implements Runnable 
             if (objectImportDirIsEmptyOrHasOnlyThisVersion) {
                 log.info("Only version directory {} present in {}, deleting parent directory", versionDirectory.getFileName(), objectImportDirectory);
                 FileUtils.deleteQuietly(objectImportDirectory.toFile());
-            } else {
+            }
+            else {
                 log.info("Deleting version directory {} if present", versionDirectory);
                 FileUtils.deleteQuietly(versionDirectory.toFile());
             }

--- a/src/main/java/nl/knaw/dans/transfer/core/SendToVaultTask.java
+++ b/src/main/java/nl/knaw/dans/transfer/core/SendToVaultTask.java
@@ -25,8 +25,10 @@ import nl.knaw.dans.lib.util.healthcheck.DependenciesReadyCheck;
 import nl.knaw.dans.transfer.client.DataVaultClient;
 import nl.knaw.dans.transfer.config.CustomPropertyConfig;
 import nl.knaw.dans.transfer.health.HealthChecks;
+import org.apache.commons.io.FileUtils;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
@@ -53,8 +55,10 @@ public class SendToVaultTask extends SourceDirItemProcessor implements Runnable 
 
     private TransferItem currentTransferItem;
 
-    public SendToVaultTask(@NonNull Path srcDir, @NonNull Path currentBatchWorkDir, @NonNull Path dataVaultBatchRoot, @NonNull DataSize batchThreshold, @NonNull Path outboxProcessed, @NonNull Path outboxFailed,
-        @NonNull DataVaultClient dataVaultClient, @NonNull String defaultMessage, @NonNull List<CustomPropertyConfig> customProperties, @NonNull FileService fileService, @NonNull DependenciesReadyCheck readyCheck,
+    public SendToVaultTask(@NonNull Path srcDir, @NonNull Path currentBatchWorkDir, @NonNull Path dataVaultBatchRoot, @NonNull DataSize batchThreshold, @NonNull Path outboxProcessed,
+        @NonNull Path outboxFailed,
+        @NonNull DataVaultClient dataVaultClient, @NonNull String defaultMessage, @NonNull List<CustomPropertyConfig> customProperties, @NonNull FileService fileService,
+        @NonNull DependenciesReadyCheck readyCheck,
         long delayBetweenProcessingRounds) {
         super(srcDir, "DVE", new DveFileFilter().toPredicate(), CreationTimeComparator.getInstance(), fileService, delayBetweenProcessingRounds);
         this.targetNbnDir = srcDir;
@@ -112,7 +116,27 @@ public class SendToVaultTask extends SourceDirItemProcessor implements Runnable 
         fileService.ensureDirectoryExists(objectImportDirectory);
         var versionDirectory = objectImportDirectory.resolve("v" + ocflObjectVersionNumber);
         log.debug("Extracting DVE {} to {}", dvePath, versionDirectory);
-        ZipUtil.extractZipFile(dvePath, versionDirectory);
+        try {
+            ZipUtil.extractZipFile(dvePath, versionDirectory);
+        }
+        catch (IOException e) {
+            log.error("Failed to extract DVE {}, deleting version directory {}", dvePath, versionDirectory, e);
+            boolean onlyVersionDirPresent = false;
+            if (Files.isDirectory(objectImportDirectory)) {
+                try (var entries = Files.list(objectImportDirectory)) {
+                    var entryList = entries.toList();
+                    onlyVersionDirPresent = entryList.size() == 1 && entryList.get(0).equals(versionDirectory);
+                }
+            }
+            if (onlyVersionDirPresent) {
+                log.info("Only version directory {} present in {}, deleting parent directory", versionDirectory.getFileName(), objectImportDirectory);
+                FileUtils.deleteQuietly(objectImportDirectory.toFile());
+            } else {
+                log.info("Deleting version directory {} if present", versionDirectory);
+                FileUtils.deleteQuietly(versionDirectory.toFile());
+            }
+            throw e;
+        }
         createVersionInfoJson(versionDirectory, currentTransferItem.getContactName(), currentTransferItem.getContactEmail(), defaultMessage);
     }
 

--- a/src/main/java/nl/knaw/dans/transfer/core/SendToVaultTask.java
+++ b/src/main/java/nl/knaw/dans/transfer/core/SendToVaultTask.java
@@ -119,16 +119,16 @@ public class SendToVaultTask extends SourceDirItemProcessor implements Runnable 
         try {
             ZipUtil.extractZipFile(dvePath, versionDirectory);
         }
-        catch (IOException e) {
+        catch (Exception e) { // Any exception!
             log.error("Failed to extract DVE {}, deleting version directory {}", dvePath, versionDirectory, e);
-            boolean onlyVersionDirPresent = false;
+            boolean objectImportDirIsEmptyOrHasOnlyThisVersion = false;
             if (Files.isDirectory(objectImportDirectory)) {
                 try (var entries = Files.list(objectImportDirectory)) {
                     var entryList = entries.toList();
-                    onlyVersionDirPresent = entryList.size() == 1 && entryList.get(0).equals(versionDirectory);
+                    objectImportDirIsEmptyOrHasOnlyThisVersion = (entryList.size() == 1 && entryList.get(0).equals(versionDirectory)) || entryList.isEmpty();
                 }
             }
-            if (onlyVersionDirPresent) {
+            if (objectImportDirIsEmptyOrHasOnlyThisVersion) {
                 log.info("Only version directory {} present in {}, deleting parent directory", versionDirectory.getFileName(), objectImportDirectory);
                 FileUtils.deleteQuietly(objectImportDirectory.toFile());
             } else {

--- a/src/test/java/nl/knaw/dans/transfer/core/SendToVaultTaskTest.java
+++ b/src/test/java/nl/knaw/dans/transfer/core/SendToVaultTaskTest.java
@@ -17,13 +17,16 @@ package nl.knaw.dans.transfer.core;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.util.DataSize;
+import nl.knaw.dans.lib.util.ZipUtil;
 import nl.knaw.dans.lib.util.healthcheck.DependenciesReadyCheck;
 import nl.knaw.dans.transfer.TestDirFixture;
 import nl.knaw.dans.transfer.client.DataVaultClient;
 import nl.knaw.dans.transfer.config.CustomPropertyConfig;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -33,6 +36,66 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class SendToVaultTaskTest extends TestDirFixture {
+    @Test
+    void addToObjectImportDirectory_should_not_delete_objectImportDirectory_if_other_versions_exist() throws Exception {
+        // Given
+        var dve = testDir.resolve("fail.zip");
+        var currentBatchWorkDir = testDir.resolve("batch");
+        var dataVaultBatchRoot = testDir.resolve("vault");
+        var outboxProcessed = testDir.resolve("processed");
+        var outboxFailed = testDir.resolve("failed");
+        var dataVaultClient = Mockito.mock(DataVaultClient.class);
+        var fileService = new FileServiceImpl();
+        var readyCheck = Mockito.mock(DependenciesReadyCheck.class);
+        var defaultMessage = "msg";
+        var customProperties = new ArrayList<CustomPropertyConfig>();
+
+        var task = new SendToVaultTask(
+            dve, currentBatchWorkDir, dataVaultBatchRoot, DataSize.bytes(0), outboxProcessed, outboxFailed,
+            dataVaultClient, defaultMessage, customProperties, fileService, readyCheck, 100
+        );
+
+        // Prepare object import directory with two versions
+        int version = 1;
+        var objectImportDirectory = testDir.resolve("object-import");
+        Files.createDirectories(objectImportDirectory);
+        var versionDirectory = objectImportDirectory.resolve("v" + version);
+        Files.createDirectories(versionDirectory);
+        var otherVersionDirectory = objectImportDirectory.resolve("v2");
+        Files.createDirectories(otherVersionDirectory);
+
+        // Set up a TransferItem with required methods
+        var transferItem = Mockito.mock(TransferItem.class);
+        Mockito.when(transferItem.getOcflObjectVersion()).thenReturn(version);
+        Mockito.when(transferItem.getNbn()).thenReturn("nbn123");
+        Mockito.when(transferItem.getContactName()).thenReturn("user");
+        Mockito.when(transferItem.getContactEmail()).thenReturn("email");
+        // Set currentTransferItem via reflection (private field)
+        var field = SendToVaultTask.class.getDeclaredField("currentTransferItem");
+        field.setAccessible(true);
+        field.set(task, transferItem);
+
+        // When / Then
+        try (MockedStatic<ZipUtil> zipUtilMock = Mockito.mockStatic(ZipUtil.class)) {
+            zipUtilMock.when(() -> ZipUtil.extractZipFile(Mockito.any(), Mockito.any()))
+                .thenThrow(new RuntimeException("Extraction failed"));
+            var method = task.getClass().getDeclaredMethod("addToObjectImportDirectory", Path.class, int.class, Path.class);
+            method.setAccessible(true);
+            Throwable thrown = null;
+            try {
+                method.invoke(task, dve, version, objectImportDirectory);
+            } catch (InvocationTargetException e) {
+                thrown = e.getCause();
+            }
+            assertThat(thrown)
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("Extraction failed");
+            // Only the failed version directory should be deleted, not the parent or other version
+            assertThat(Files.exists(objectImportDirectory)).isTrue();
+            assertThat(Files.exists(versionDirectory)).isFalse();
+            assertThat(Files.exists(otherVersionDirectory)).isTrue();
+        }
+    }
 
     @Test
     public void createVersionInfoProperties_should_handle_special_characters_and_whitespace() throws Exception {
@@ -77,5 +140,62 @@ public class SendToVaultTaskTest extends TestDirFixture {
         assertThat(userObj.get("name")).isEqualTo("John Doe");
         assertThat(userObj.get("email")).isEqualTo("john@example.com");
         assertThat(versionInfo.get("message")).isEqualTo(message);
+    }
+
+    @Test
+    void addToObjectImportDirectory_should_cleanup_on_extraction_failure() throws Exception {
+        // Given
+        Path dve = testDir.resolve("fail.zip");
+        Path currentBatchWorkDir = testDir.resolve("batch");
+        Path dataVaultBatchRoot = testDir.resolve("vault");
+        Path outboxProcessed = testDir.resolve("processed");
+        Path outboxFailed = testDir.resolve("failed");
+        DataVaultClient dataVaultClient = Mockito.mock(DataVaultClient.class);
+        FileService fileService = new FileServiceImpl();
+        DependenciesReadyCheck readyCheck = Mockito.mock(DependenciesReadyCheck.class);
+        String defaultMessage = "msg";
+        List<CustomPropertyConfig> customProperties = new ArrayList<>();
+
+        var task = new SendToVaultTask(
+            dve, currentBatchWorkDir, dataVaultBatchRoot, DataSize.bytes(0), outboxProcessed, outboxFailed,
+            dataVaultClient, defaultMessage, customProperties, fileService, readyCheck, 100
+        );
+
+        // Prepare version directory
+        int version = 1;
+        Path objectImportDirectory = testDir.resolve("object-import");
+        Files.createDirectories(objectImportDirectory);
+        Path versionDirectory = objectImportDirectory.resolve("v" + version);
+        Files.createDirectories(versionDirectory);
+
+        // Set up a TransferItem with required methods
+        var transferItem = Mockito.mock(TransferItem.class);
+        Mockito.when(transferItem.getOcflObjectVersion()).thenReturn(version);
+        Mockito.when(transferItem.getNbn()).thenReturn("nbn123");
+        Mockito.when(transferItem.getContactName()).thenReturn("user");
+        Mockito.when(transferItem.getContactEmail()).thenReturn("email");
+        // Set currentTransferItem via reflection (private field)
+        var field = SendToVaultTask.class.getDeclaredField("currentTransferItem");
+        field.setAccessible(true);
+        field.set(task, transferItem);
+
+        // When / Then
+        try (MockedStatic<ZipUtil> zipUtilMock = Mockito.mockStatic(ZipUtil.class)) {
+            zipUtilMock.when(() -> ZipUtil.extractZipFile(Mockito.any(), Mockito.any()))
+                .thenThrow(new RuntimeException("Extraction failed"));
+            var method = task.getClass().getDeclaredMethod("addToObjectImportDirectory", Path.class, int.class, Path.class);
+            method.setAccessible(true);
+            Throwable thrown = null;
+            try {
+                method.invoke(task, dve, version, objectImportDirectory);
+            } catch (InvocationTargetException e) {
+                thrown = e.getCause();
+            }
+            assertThat(thrown)
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("Extraction failed");
+            // Directory should be deleted (parent or version dir)
+            assertThat(Files.exists(objectImportDirectory)).isFalse();
+        }
     }
 }


### PR DESCRIPTION
Fixes DD-2249

# Description of changes
In SendToVaultTask, if the unzipping of the DVE fails, an attempt is made to remove anything that was created by the unzip action (i.e. to make sure a partially unzipped DVE is not left in the work-directory).

# How to test
* Create a dataset with a conflicting label and directoryLabel (see DD-2248) and archive that. This will result in an error during unzip.

# Notify
@DANS-KNAW/core-systems
