### PR TITLE
DD-2235

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,83 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "master" ]
+  schedule:
+    - cron: '33 19 * * 6'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'java' ]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Use only 'java' to analyze code written in Java, Kotlin or both
+        # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both
+        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+          cache: 'maven'
+
+        # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+
+          # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+          # queries: security-extended,security-and-quality
+
+
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+
+      #   If the Autobuild fails above, remove it and uncomment the following three lines.
+      #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+
+      # - run: |
+      #     echo "Run, Build Application using script"
+      #     ./location_of_script_within_repo/buildscript.sh
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{matrix.language}}"

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     </parent>
 
     <artifactId>dd-transfer-to-vault</artifactId>
-    <version>3.3.5-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
 
     <name>DD Transfer To Vault</name>
     <url>https://github.com/DANS-KNAW/dd-transfer-to-vault</url>
@@ -38,6 +38,7 @@
         <dd-transfer-to-vault-api.version>0.1.0</dd-transfer-to-vault-api.version>
         <dans-java-utils.version>2.10.1</dans-java-utils.version>
         <dd-vault-catalog-api.version>1.0.0</dd-vault-catalog-api.version>
+        <dd-lob-store-api.version>0.2.1-SNAPSHOT</dd-lob-store-api.version>
     </properties>
 
     <scm>
@@ -210,6 +211,12 @@
                                     <version>${dd-validate-bagpack-api.version}</version>
                                     <outputDirectory>${project.build.directory}/openapi</outputDirectory>
                                 </artifactItem>
+                                <artifactItem>
+                                    <groupId>nl.knaw.dans</groupId>
+                                    <artifactId>dd-lob-store-api</artifactId>
+                                    <version>${dd-lob-store-api.version}</version>
+                                    <outputDirectory>${project.build.directory}/openapi</outputDirectory>
+                                </artifactItem>
                             </artifactItems>
                         </configuration>
                     </execution>
@@ -308,6 +315,24 @@
                                 <apiPackage>nl.knaw.dans.validatebagpack.client.resources</apiPackage>
                                 <modelPackage>nl.knaw.dans.validatebagpack.client.api</modelPackage>
                                 <invokerPackage>nl.knaw.dans.validatebagpack.client.invoker</invokerPackage>
+                                <annotationLibrary>none</annotationLibrary>
+                                <library>jersey2</library>
+                                <openApiNullable>false</openApiNullable>
+                            </configOptions>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>lob-store-client</id>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <inputSpec>${project.build.directory}/openapi/dd-lob-store-api.yml</inputSpec>
+                            <generatorName>java</generatorName>
+                            <apiPackage>nl.knaw.dans.lobstore.client.resources</apiPackage>
+                            <modelPackage>nl.knaw.dans.lobstore.client.api</modelPackage>
+                            <invokerPackage>nl.knaw.dans.lobstore.client.invoker</invokerPackage>
+                            <configOptions>
                                 <annotationLibrary>none</annotationLibrary>
                                 <library>jersey2</library>
                                 <openApiNullable>false</openApiNullable>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <dd-transfer-to-vault-api.version>0.1.0</dd-transfer-to-vault-api.version>
         <dans-java-utils.version>2.10.1</dans-java-utils.version>
         <dd-vault-catalog-api.version>1.0.0</dd-vault-catalog-api.version>
-        <dd-lob-store-api.version>0.2.1-SNAPSHOT</dd-lob-store-api.version>
+        <dd-lob-store-api.version>0.2.0</dd-lob-store-api.version>
     </properties>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     </parent>
 
     <artifactId>dd-transfer-to-vault</artifactId>
-    <version>3.4.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
 
     <name>DD Transfer To Vault</name>
     <url>https://github.com/DANS-KNAW/dd-transfer-to-vault</url>

--- a/src/main/assembly/dist/cfg/config.yml
+++ b/src/main/assembly/dist/cfg/config.yml
@@ -123,6 +123,11 @@ health:
       initialState: false
       schedule:
         checkInterval: 60s
+    - name: LobStore
+      critical: true
+      initialState: false
+      schedule:
+        checkInterval: 60s
   initialOverallState: false
 
 vaultCatalog:
@@ -167,6 +172,16 @@ validateBagPack:
     retries: 2
     userAgent: dd-transfer-to-vault
 
+lobStore:
+  url: http://localhost:20385
+  pingUrl: http://localhost:20386/ping
+  httpClient:
+    timeout: 30s
+    connectionTimeout: 15s
+    timeToLive: 1h
+    retries: 2
+    userAgent: dd-transfer-to-vault
+
 readyCheck:
   # Health checks to include in the ready check
   healthChecks:
@@ -176,6 +191,7 @@ readyCheck:
     - VaultCatalog
     - DataVault
     - ValidateBagPack
+    - LobStore
   pollInterval: 5s
 
 #

--- a/src/main/assembly/dist/cfg/config.yml
+++ b/src/main/assembly/dist/cfg/config.yml
@@ -22,9 +22,11 @@ transfer:
   # Minimum free space that must be available in the workspace before processing a new DVE. This uses the FileSystemFreeSpace health check
   # to determine the available free space.
   workspaceFreeSpaceThreshold: 1GB
-  # Value to store in the 'ocfl_storage_root' field of the dataset's vault catalog record. Not required for VaaS, because dd-vault-ingest
-  # already adds this column in the skeleton record.
-  ocflStorageRoot: null
+  # For Data Stations: set to the name of the data station. This will be used as the 'ocfl_storage_root'
+  # in the dataset's vault catalog record, and to retrieve LOBs from the LOB Store.
+  # For VaaS: leave null, as the storage root is pre-configured in the Vault Catalog.
+  # Note: Holey bags (fetch.txt) are only supported if this value is provided.
+  datastationName: null
   # Collect the DVE from the transfer-inbox and determine its target NBN
   collectDve:
     addTimestampToCollectedItems: true

--- a/src/main/java/nl/knaw/dans/transfer/DdTransferToVaultApplication.java
+++ b/src/main/java/nl/knaw/dans/transfer/DdTransferToVaultApplication.java
@@ -112,7 +112,7 @@ public class DdTransferToVaultApplication extends Application<DdTransferToVaultC
                 .fileService(fileService)
                 .dveMetadataReader(dveMetadataReader)
                 .lobStoreClient(lobStoreClient)
-                .datastation(configuration.getTransfer().getOcflStorageRoot())
+                .datastationName(configuration.getTransfer().getDatastationName())
                 .readyCheck(healthCheckReadyCheck)
                 .delayBetweenProcessingRounds(configuration.getTransfer().getSendToVault().getDelayBetweenProcessingRounds().toMilliseconds())
                 .build())
@@ -141,7 +141,7 @@ public class DdTransferToVaultApplication extends Application<DdTransferToVaultC
                 .fileFilter(new NbnDirectoryFilter())
                 .taskFactory(
                     ExtractMetadataTaskFactory.builder()
-                        .ocflStorageRoot(configuration.getTransfer().getOcflStorageRoot())
+                        .datastationName(configuration.getTransfer().getDatastationName())
                         .outboxProcessed(configuration.getTransfer().getExtractMetadata().getOutbox().getProcessed())
                         .outboxFailed(configuration.getTransfer().getExtractMetadata().getOutbox().getFailed())
                         .outboxRejected(configuration.getTransfer().getExtractMetadata().getOutbox().getRejected())

--- a/src/main/java/nl/knaw/dans/transfer/DdTransferToVaultApplication.java
+++ b/src/main/java/nl/knaw/dans/transfer/DdTransferToVaultApplication.java
@@ -27,6 +27,7 @@ import nl.knaw.dans.lib.util.healthcheck.FileSystemFreeSpaceHealthCheck;
 import nl.knaw.dans.lib.util.healthcheck.HealthChecksDependenciesReadyCheck;
 import nl.knaw.dans.lib.util.inbox.Inbox;
 import nl.knaw.dans.transfer.client.DataVaultClient;
+import nl.knaw.dans.transfer.client.LobStoreClient;
 import nl.knaw.dans.transfer.client.ValidateBagPackClient;
 import nl.knaw.dans.transfer.client.ValidateBagPackClientImpl;
 import nl.knaw.dans.transfer.client.VaultCatalogClient;
@@ -85,6 +86,15 @@ public class DdTransferToVaultApplication extends Application<DdTransferToVaultC
         // Single-threaded executor to coordinate batch threshold checks
         var sendToVaultExecutorService = environment.lifecycle().executorService("send-to-vault-worker").minThreads(1).maxThreads(1).build();
         var datavaultClient = new DataVaultClient(dataVaultProxy);
+
+        var lobStoreProxy = createLobStoreProxy(configuration);
+        var lobStoreClient = new LobStoreClient(lobStoreProxy);
+
+        var dveMetadataReader = new DveMetadataReader(
+            fileService,
+            new OaiOreMetadataReader(),
+            new DataFileMetadataReader(fileService));
+
         environment.lifecycle().manage(Inbox.builder()
             .executorService(sendToVaultExecutorService)
             .fileFilter(new NbnDirectoryFilter())
@@ -100,6 +110,9 @@ public class DdTransferToVaultApplication extends Application<DdTransferToVaultC
                 .defaultMessage(configuration.getTransfer().getSendToVault().getDefaultMessage())
                 .customProperties(configuration.getTransfer().getSendToVault().getCustomProperties())
                 .fileService(fileService)
+                .dveMetadataReader(dveMetadataReader)
+                .lobStoreClient(lobStoreClient)
+                .datastation(configuration.getTransfer().getOcflStorageRoot())
                 .readyCheck(healthCheckReadyCheck)
                 .delayBetweenProcessingRounds(configuration.getTransfer().getSendToVault().getDelayBetweenProcessingRounds().toMilliseconds())
                 .build())
@@ -197,6 +210,12 @@ public class DdTransferToVaultApplication extends Application<DdTransferToVaultC
             validateBagPackProxy.getApiClient().getHttpClient(),
             configuration.getValidateBagPack().getPingUrl())
         );
+        environment.healthChecks().register(HealthChecks.LOB_STORE, new PingHealthCheck(
+            HealthChecks.LOB_STORE,
+            lobStoreProxy.getApiClient().getHttpClient(),
+            configuration.getLobStore().getPingUrl())
+        );
+        
     }
 
     private DefaultApi createVaultCatalogProxy(DdTransferToVaultConfiguration configuration) {
@@ -226,11 +245,20 @@ public class DdTransferToVaultApplication extends Application<DdTransferToVaultC
             .build();
     }
 
+    private nl.knaw.dans.lobstore.client.resources.DefaultApi createLobStoreProxy(DdTransferToVaultConfiguration configuration) {
+        return new ClientProxyBuilder<nl.knaw.dans.lobstore.client.invoker.ApiClient, nl.knaw.dans.lobstore.client.resources.DefaultApi>()
+            .apiClient(new nl.knaw.dans.lobstore.client.invoker.ApiClient())
+            .basePath(configuration.getLobStore().getUrl())
+            .httpClient(configuration.getLobStore().getHttpClient())
+            .defaultApiCtor(nl.knaw.dans.lobstore.client.resources.DefaultApi::new)
+            .build();
+    }
+
     private void checkReadyCheckConfig(DependenciesReadyCheckConfig config) {
         if (!new HashSet<>(config.getHealthChecks())
-            .containsAll(List.of(HealthChecks.FILESYSTEM_PERMISSIONS, HealthChecks.DATA_VAULT, HealthChecks.VAULT_CATALOG, HealthChecks.VALIDATE_BAG_PACK, HealthChecks.FILESYSTEM_FREE_SPACE))) {
+            .containsAll(List.of(HealthChecks.FILESYSTEM_PERMISSIONS, HealthChecks.DATA_VAULT, HealthChecks.VAULT_CATALOG, HealthChecks.VALIDATE_BAG_PACK, HealthChecks.FILESYSTEM_FREE_SPACE, HealthChecks.LOB_STORE))) {
             throw new IllegalArgumentException(String.format("Ready check configuration must include at least: %s",
-                List.of(HealthChecks.FILESYSTEM_PERMISSIONS, HealthChecks.DATA_VAULT, HealthChecks.VAULT_CATALOG, HealthChecks.VALIDATE_BAG_PACK, HealthChecks.FILESYSTEM_FREE_SPACE)));
+                List.of(HealthChecks.FILESYSTEM_PERMISSIONS, HealthChecks.DATA_VAULT, HealthChecks.VAULT_CATALOG, HealthChecks.VALIDATE_BAG_PACK, HealthChecks.FILESYSTEM_FREE_SPACE, HealthChecks.LOB_STORE)));
         }
     }
 

--- a/src/main/java/nl/knaw/dans/transfer/client/LobStoreClient.java
+++ b/src/main/java/nl/knaw/dans/transfer/client/LobStoreClient.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2025 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.transfer.client;
+
+import lombok.extern.slf4j.Slf4j;
+import nl.knaw.dans.lobstore.client.api.TransferRequestDto;
+import nl.knaw.dans.lobstore.client.resources.DefaultApi;
+
+import java.util.List;
+
+@Slf4j
+public class LobStoreClient {
+    private final DefaultApi api;
+
+    public LobStoreClient(DefaultApi api) {
+        this.api = api;
+    }
+
+    public void requestTransfers(List<TransferRequestDto> requests) {
+        if (requests.isEmpty()) {
+            return;
+        }
+
+        log.debug("Requesting dd-lob-store to process {} large objects", requests.size());
+        try {
+            var results = api.addTransfers(requests);
+            log.debug("dd-lob-store processed {} requests", results.size());
+        }
+        catch (Exception e) {
+            log.error("Error communicating with dd-lob-store", e);
+        }
+    }
+}

--- a/src/main/java/nl/knaw/dans/transfer/client/VaultCatalogClientImpl.java
+++ b/src/main/java/nl/knaw/dans/transfer/client/VaultCatalogClientImpl.java
@@ -137,7 +137,7 @@ public class VaultCatalogClientImpl implements VaultCatalogClient {
         dveDto.setFileMetas(new ArrayList<>()); // clear existing fileMetas. N.B. empty array and not null, to avoid NPE for empty dataset.
         for (var dataFile : dveMetadata.getDataFileAttributes()) {
             var dataFileDto = new FileMetaDto()
-                .filepath(removeBaseFolder(dataFile.getFilepath()).toString())
+                .filepath(removeBaseFolder(Path.of(dataFile.getFilepath())).toString())
                 .fileUri(dataFile.getUri())
                 .byteSize(dataFile.getSize())
                 .sha1sum(dataFile.getSha1Checksum());

--- a/src/main/java/nl/knaw/dans/transfer/config/DdTransferToVaultConfiguration.java
+++ b/src/main/java/nl/knaw/dans/transfer/config/DdTransferToVaultConfiguration.java
@@ -41,6 +41,10 @@ public class DdTransferToVaultConfiguration extends Configuration {
 
     @Valid
     @NotNull
+    private LobStoreConfig lobStore;
+
+    @Valid
+    @NotNull
     private ValidateBagPackConfig validateBagPack;
 
     @Valid

--- a/src/main/java/nl/knaw/dans/transfer/config/LobStoreConfig.java
+++ b/src/main/java/nl/knaw/dans/transfer/config/LobStoreConfig.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2025 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.transfer.config;
+
+import io.dropwizard.client.JerseyClientConfiguration;
+import lombok.Data;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.net.URI;
+
+@Data
+public class LobStoreConfig {
+    @NotNull
+    private URI url;
+
+    @NotNull
+    private URI pingUrl;
+
+    @Valid
+    @NotNull
+    private JerseyClientConfiguration httpClient = new JerseyClientConfiguration();
+}

--- a/src/main/java/nl/knaw/dans/transfer/config/TransferConfig.java
+++ b/src/main/java/nl/knaw/dans/transfer/config/TransferConfig.java
@@ -23,7 +23,7 @@ import javax.validation.constraints.NotNull;
 
 @Data
 public class TransferConfig {
-    private String ocflStorageRoot;
+    private String datastationName;
 
     // Single threshold for workspace free space
     @NotNull

--- a/src/main/java/nl/knaw/dans/transfer/core/DataFileMetadata.java
+++ b/src/main/java/nl/knaw/dans/transfer/core/DataFileMetadata.java
@@ -22,7 +22,7 @@ import java.nio.file.Path;
 
 @Value
 public class DataFileMetadata {
-    Path filepath;
+    String filepath;
     URI uri;
     String sha1Checksum;
     long size;

--- a/src/main/java/nl/knaw/dans/transfer/core/DataFileMetadataReader.java
+++ b/src/main/java/nl/knaw/dans/transfer/core/DataFileMetadataReader.java
@@ -43,6 +43,16 @@ public class DataFileMetadataReader {
             var pathToSha1Map = readPathToSha1Mapping(sha1Manifest);
             var pathToSizeMap = readPathToSizeMapping(datasetVersionExport);
 
+            try {
+                var fetchContentStream = fileService.getEntryUnderBaseFolder(datasetVersionExport, Path.of("fetch.txt"));
+                var fetchContent = IOUtils.toString(fetchContentStream, StandardCharsets.UTF_8);
+                var fetchSizeMap = readPathToFetchSizeMapping(fetchContent);
+                pathToSizeMap.putAll(fetchSizeMap);
+            }
+            catch (IllegalArgumentException e) {
+                // fetch.txt not found, ignore
+            }
+
             return pathToPidMap.entrySet().stream()
                 .filter(e -> pathToSha1Map.containsKey(e.getKey()))
                 .map(entry -> {
@@ -54,6 +64,20 @@ public class DataFileMetadataReader {
                 })
                 .toList();
         }
+    }
+
+    private Map<Path, Long> readPathToFetchSizeMapping(String fetchContent) {
+        var fetchSizeMap = new HashMap<Path, Long>();
+        fetchContent.lines().forEach(line -> {
+            if (!line.isBlank()) {
+                var parts = line.split("\\s+", 3);
+                if (parts.length == 3) {
+                    var size = parts[1].equals("-") ? -1L : Long.parseLong(parts[1]);
+                    fetchSizeMap.put(Path.of(parts[2]), size);
+                }
+            }
+        });
+        return fetchSizeMap;
     }
 
     Map<Path, Long> readPathToSizeMapping(ZipFile dve) throws IOException {

--- a/src/main/java/nl/knaw/dans/transfer/core/DataFileMetadataReader.java
+++ b/src/main/java/nl/knaw/dans/transfer/core/DataFileMetadataReader.java
@@ -47,7 +47,7 @@ public class DataFileMetadataReader {
             try (var topLevelDirStream = fileService.list(rootDir)) {
                 var topLevelDir = topLevelDirStream
                     .filter(fileService::isDirectory)
-                    .findFirst()
+                    .findFirst() // This relies on bag validation having rejected any packages with multiple toplevel dirs.
                     .orElseThrow(() -> new IllegalStateException("No top-level directory found in DVE"));
 
                 var pidMappingContent = fileService.newInputStream(topLevelDir.resolve("metadata/pid-mapping.txt"));

--- a/src/main/java/nl/knaw/dans/transfer/core/DataFileMetadataReader.java
+++ b/src/main/java/nl/knaw/dans/transfer/core/DataFileMetadataReader.java
@@ -16,122 +16,101 @@
 package nl.knaw.dans.transfer.core;
 
 import lombok.AllArgsConstructor;
+import nl.knaw.dans.bagit.domain.Bag;
+import nl.knaw.dans.bagit.domain.FetchItem;
+import nl.knaw.dans.bagit.hash.StandardSupportedAlgorithms;
+import nl.knaw.dans.bagit.reader.BagReader;
 import org.apache.commons.io.IOUtils;
 
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystem;
 import java.nio.file.Path;
+import java.nio.file.ProviderNotFoundException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
 
 @AllArgsConstructor
 public class DataFileMetadataReader {
     private final FileService fileService;
 
     public List<DataFileMetadata> readDataFileAttributes(Path dveZip) throws IOException {
-        try (var datasetVersionExport = fileService.openZipFile(dveZip)) {
-            var pidMappingContent = fileService.getEntryUnderBaseFolder(datasetVersionExport, Path.of("metadata/pid-mapping.txt"));
-            var sha1ManifestContent = fileService.getEntryUnderBaseFolder(datasetVersionExport, Path.of("manifest-sha1.txt"));
-            var pidMapping = IOUtils.toString(pidMappingContent, StandardCharsets.UTF_8);
-            var sha1Manifest = IOUtils.toString(sha1ManifestContent, StandardCharsets.UTF_8);
-            var pathToPidMap = readPathToPidMapping(pidMapping);
-            var pathToSha1Map = readPathToSha1Mapping(sha1Manifest);
-            var pathToSizeMap = readPathToSizeMapping(datasetVersionExport);
-
-            try {
-                var fetchContentStream = fileService.getEntryUnderBaseFolder(datasetVersionExport, Path.of("fetch.txt"));
-                var fetchContent = IOUtils.toString(fetchContentStream, StandardCharsets.UTF_8);
-                var fetchSizeMap = readPathToFetchSizeMapping(fetchContent);
-                pathToSizeMap.putAll(fetchSizeMap);
+        try (var zipFs = fileService.newFileSystem(dveZip)) {
+            if (zipFs == null) {
+                throw new IOException("Failed to open file system for " + dveZip);
             }
-            catch (IllegalArgumentException e) {
-                // fetch.txt not found, ignore
-            }
+            var rootDir = zipFs.getRootDirectories().iterator().next();
+            try (var topLevelDirStream = fileService.list(rootDir)) {
+                var topLevelDir = topLevelDirStream
+                    .filter(fileService::isDirectory)
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException("No top-level directory found in DVE"));
 
-            return pathToPidMap.entrySet().stream()
-                .filter(e -> pathToSha1Map.containsKey(e.getKey()))
-                .map(entry -> {
-                    var path = entry.getKey();
-                    var pid = entry.getValue();
-                    var sha1 = pathToSha1Map.get(path);
-                    var size = pathToSizeMap.get(path);
-                    return new DataFileMetadata(path, pid, sha1, size);
-                })
-                .toList();
+                var pidMappingContent = fileService.newInputStream(topLevelDir.resolve("metadata/pid-mapping.txt"));
+                var pidMapping = IOUtils.toString(pidMappingContent, StandardCharsets.UTF_8);
+                var pathToPidMap = readPathToPidMapping(pidMapping);
+
+                BagReader reader = new BagReader();
+                Bag bag = reader.read(topLevelDir);
+
+                var pathToSha1Map = bag.getPayLoadManifests().stream()
+                    .filter(m -> m.getAlgorithm() == StandardSupportedAlgorithms.SHA1)
+                    .findFirst()
+                    .map(m -> m.getFileToChecksumMap().entrySet().stream()
+                        .collect(Collectors.toMap(entry -> topLevelDir.relativize(entry.getKey()).toString(), Map.Entry::getValue)))
+                    .orElse(Map.of());
+
+                var pathToFetchItemMap = bag.getItemsToFetch().stream()
+                    .collect(Collectors.toMap(item -> topLevelDir.relativize(item.getPath()).toString(), item -> item));
+
+                return pathToPidMap.entrySet().stream()
+                    .filter(e -> pathToSha1Map.containsKey(e.getKey()))
+                    .map(entry -> {
+                        var path = entry.getKey();
+                        var pid = entry.getValue();
+                        var sha1 = pathToSha1Map.get(path);
+                        var fetchItem = pathToFetchItemMap.get(path);
+                        long size;
+                        if (fetchItem != null) {
+                            size = fetchItem.length == null ? -1L : fetchItem.length;
+                        }
+                        else {
+                            try {
+                                size = fileService.readAttributes(topLevelDir.resolve(path), java.nio.file.attribute.BasicFileAttributes.class).size();
+                            }
+                            catch (IOException e) {
+                                size = -1L;
+                            }
+                        }
+                        return new DataFileMetadata(path, pid, sha1, size);
+                    })
+                    .toList();
+            }
+        }
+        catch (ProviderNotFoundException e) {
+            throw new RuntimeException("The file system provider is not found. Probably not a ZIP file: " + dveZip, e);
+        }
+        catch (Exception e) {
+            throw new IOException("Error reading data file attributes from " + dveZip, e);
         }
     }
 
-    private Map<Path, Long> readPathToFetchSizeMapping(String fetchContent) {
-        var fetchSizeMap = new HashMap<Path, Long>();
-        fetchContent.lines().forEach(line -> {
-            if (!line.isBlank()) {
-                var parts = line.split("\\s+", 3);
-                if (parts.length == 3) {
-                    var size = parts[1].equals("-") ? -1L : Long.parseLong(parts[1]);
-                    fetchSizeMap.put(Path.of(parts[2]), size);
-                }
-            }
-        });
-        return fetchSizeMap;
-    }
-
-    Map<Path, Long> readPathToSizeMapping(ZipFile dve) throws IOException {
-        var pathToSizeMap = new HashMap<Path, Long>();
-        var dveEntries = dve.stream().toList();
-        var baseFolder = findBaseFolder(dveEntries);
-        dveEntries.stream()
-            .filter(entry -> !entry.isDirectory())
-            .forEach(entry -> {
-                var entryPath = Path.of(entry.getName());
-                var size = entry.getSize();
-                pathToSizeMap.put(baseFolder.relativize(entryPath), size);
-            });
-        return pathToSizeMap;
-    }
-
-    /*
-     * There should be a common base folder for the whole ZIP file. If there are multiple base folders, an exception should be thrown.
-     * Inside the common base folder there should be a "data" folder. Return the path to the "data" folder.
-     */
-    Path findBaseFolder(List<? extends ZipEntry> entries) {
-        var baseFolders = entries.stream()
-            .map(ZipEntry::getName)
-            .map(name -> name.split("/")[0])
-            .distinct()
-            .toList();
-        if (baseFolders.size() != 1) {
-            throw new IllegalArgumentException("There should be a common base folder for the whole ZIP file.");
-        }
-        return Path.of(baseFolders.get(0));
-    }
-
-    Map<Path, URI> readPathToPidMapping(String pidToPathMapping) throws IOException {
-        var pathToPidMap = new HashMap<Path, URI>();
+    Map<String, URI> readPathToPidMapping(String pidToPathMapping) throws IOException {
+        var pathToPidMap = new HashMap<String, URI>();
         try (var lines = pidToPathMapping.lines()) {
             lines.map(line -> line.split("\\s+", 2))
                 .forEach(parts -> {
                     if (parts[1].equals("data/")) {
-                        return;
+                        return; // Entry for the complete dataset can be ignored
                     }
-                    pathToPidMap.put(Path.of(parts[1]), URI.create(parts[0]));
+                    var pathStr = parts[1];
+                    pathToPidMap.put(pathStr, URI.create(parts[0]));
                 });
 
         }
         return pathToPidMap;
-    }
-
-    Map<Path, String> readPathToSha1Mapping(String sha1ToPathMapping) throws IOException {
-        HashMap<Path, String> pathToSha1Map;
-        try (var lines = sha1ToPathMapping.lines()) {
-            pathToSha1Map = lines
-                .map(line -> line.split("\\s+", 2))
-                .collect(Collectors.toMap(parts -> Path.of(parts[1]), parts -> parts[0], (a, b) -> b, HashMap::new));
-        }
-        return pathToSha1Map;
     }
 }

--- a/src/main/java/nl/knaw/dans/transfer/core/DataFileMetadataReader.java
+++ b/src/main/java/nl/knaw/dans/transfer/core/DataFileMetadataReader.java
@@ -50,8 +50,10 @@ public class DataFileMetadataReader {
                     .findFirst()
                     .orElseThrow(() -> new IllegalStateException("No top-level directory found in DVE"));
 
-                var pidMappingContent = fileService.newInputStream(topLevelDir.resolve("metadata/pid-mapping.txt"));
-                var pidMapping = IOUtils.toString(pidMappingContent, StandardCharsets.UTF_8);
+                String pidMapping;
+                try (var pidMappingContent = fileService.newInputStream(topLevelDir.resolve("metadata/pid-mapping.txt"))) {
+                    pidMapping = IOUtils.toString(pidMappingContent, StandardCharsets.UTF_8);
+                }
                 var pathToPidMap = readPathToPidMapping(pidMapping);
 
                 BagReader reader = new BagReader();

--- a/src/main/java/nl/knaw/dans/transfer/core/DataFileMetadataReader.java
+++ b/src/main/java/nl/knaw/dans/transfer/core/DataFileMetadataReader.java
@@ -28,6 +28,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystem;
 import java.nio.file.Path;
 import java.nio.file.ProviderNotFoundException;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -79,7 +80,7 @@ public class DataFileMetadataReader {
                         }
                         else {
                             try {
-                                size = fileService.readAttributes(topLevelDir.resolve(path), java.nio.file.attribute.BasicFileAttributes.class).size();
+                                size = fileService.readAttributes(topLevelDir.resolve(path), BasicFileAttributes.class).size();
                             }
                             catch (IOException e) {
                                 size = -1L;

--- a/src/main/java/nl/knaw/dans/transfer/core/DveMetadata.java
+++ b/src/main/java/nl/knaw/dans/transfer/core/DveMetadata.java
@@ -38,7 +38,6 @@ public class DveMetadata {
     private String otherIdVersion;
     private String swordToken;
     private String dataSupplier;
-    private String datastation;
     private String exporter;
     private String exporterVersion;
     private List<DataFileMetadata> dataFileAttributes;

--- a/src/main/java/nl/knaw/dans/transfer/core/ExtractMetadataTask.java
+++ b/src/main/java/nl/knaw/dans/transfer/core/ExtractMetadataTask.java
@@ -27,7 +27,7 @@ import java.nio.file.Path;
 
 @Slf4j
 public class ExtractMetadataTask extends SourceDirItemProcessor implements Runnable {
-    private final String ocflStorageRoot;
+    private final String datastationName;
     private final Path targetNbnDir;
     private final Path outboxProcessed;
     private final Path outboxFailed;
@@ -41,14 +41,14 @@ public class ExtractMetadataTask extends SourceDirItemProcessor implements Runna
 
     private TransferItem currentTransferItem;
 
-    public ExtractMetadataTask(Path srcDir, String ocflStorageRoot, Path outboxProcessed, Path outboxFailed, Path outboxRejected,
+    public ExtractMetadataTask(Path srcDir, String datastationName, Path outboxProcessed, Path outboxFailed, Path outboxRejected,
         Path nbnRegistrationInbox, URI vaultCatalogBaseUri, DveMetadataReader dveMetadataReader,
         FileService fileService, VaultCatalogClient vaultCatalogClient,
         ValidateBagPackClient validateBagPackClient, DependenciesReadyCheck readyCheck,
         long delayBetweenProcessingRounds) {
         super(srcDir, "DVE", new DveFileFilter().toPredicate(), CreationTimeComparator.getInstance(), fileService, delayBetweenProcessingRounds);
         this.targetNbnDir = srcDir;
-        this.ocflStorageRoot = ocflStorageRoot;
+        this.datastationName = datastationName;
         this.outboxProcessed = outboxProcessed;
         this.outboxFailed = outboxFailed;
         this.outboxRejected = outboxRejected;
@@ -71,7 +71,7 @@ public class ExtractMetadataTask extends SourceDirItemProcessor implements Runna
 
     @Override
     protected void processItem(Path item) throws IOException {
-        currentTransferItem = new TransferItem(item, fileService);
+        currentTransferItem = createTransferItem(item);
 
         log.debug("Validating DVE {} as BagPack...", item);
         var result = validateBagPackClient.validateBagPack(item);
@@ -86,10 +86,14 @@ public class ExtractMetadataTask extends SourceDirItemProcessor implements Runna
         log.debug("Reading metadata from dve");
         var dveMetadata = dveMetadataReader.readDveMetadata(item);
 
+        if (!currentTransferItem.getFetchSha1s().isEmpty() && datastationName == null) {
+            throw new IllegalArgumentException("Holey bags (with fetch.txt) are not supported for VaaS customers yet.");
+        }
+
         log.debug("Registering OCFL Object Version in Vault Catalog");
         boolean deaccessioned = currentTransferItem.getDeaccessionedReason().isPresent();
         currentTransferItem.setOcflObjectVersion(
-            vaultCatalogClient.registerOcflObjectVersion(ocflStorageRoot, dveMetadata, currentTransferItem.getOcflObjectVersion(), deaccessioned));
+            vaultCatalogClient.registerOcflObjectVersion(datastationName, dveMetadata, currentTransferItem.getOcflObjectVersion(), deaccessioned));
 
         if (currentTransferItem.getOcflObjectVersion() == 1) {
             log.info("First version of dataset {}. Scheduling NBN registration", currentTransferItem.getNbn());
@@ -108,6 +112,10 @@ public class ExtractMetadataTask extends SourceDirItemProcessor implements Runna
             Thread.currentThread().interrupt();
             throw new IOException("Interrupted while processing items", e);
         }
+    }
+
+    protected TransferItem createTransferItem(Path item) throws IOException {
+        return new TransferItem(item, fileService);
     }
 
     @Override

--- a/src/main/java/nl/knaw/dans/transfer/core/ExtractMetadataTaskFactory.java
+++ b/src/main/java/nl/knaw/dans/transfer/core/ExtractMetadataTaskFactory.java
@@ -28,7 +28,7 @@ import java.nio.file.Path;
 @Builder
 public class ExtractMetadataTaskFactory implements InboxTaskFactory {
     @NonNull
-    private final String ocflStorageRoot;
+    private final String datastationName;
     @NonNull
     private final Path outboxProcessed;
     @NonNull
@@ -53,7 +53,7 @@ public class ExtractMetadataTaskFactory implements InboxTaskFactory {
 
     @Override
     public Runnable createInboxTask(Path targetNbnDir) {
-        return new ExtractMetadataTask(targetNbnDir, ocflStorageRoot, outboxProcessed, outboxFailed, outboxRejected,
+        return new ExtractMetadataTask(targetNbnDir, datastationName, outboxProcessed, outboxFailed, outboxRejected,
             nbnRegistrationInbox, vaultCatalogBaseUri, dveMetadataReader, fileService,
             vaultCatalogClient, validateBagPackClient, readyCheck, delayBetweenProcessingRounds);
     }

--- a/src/main/java/nl/knaw/dans/transfer/core/SendToVaultTask.java
+++ b/src/main/java/nl/knaw/dans/transfer/core/SendToVaultTask.java
@@ -167,6 +167,19 @@ public class SendToVaultTask extends SourceDirItemProcessor implements Runnable 
             root.put("object-version-properties", custom);
         }
 
+        try {
+            var lobs = currentTransferItem.getFetchSha1s();
+            if (lobs != null && !lobs.isEmpty()) {
+                Map<String, Object> externalLargeObjects = new HashMap<>();
+                externalLargeObjects.put("checksum-algorithm", "sha1");
+                externalLargeObjects.put("lobs", lobs);
+                root.put("external-large-objects", externalLargeObjects);
+            }
+        }
+        catch (IOException e) {
+            log.error("Failed to read fetch SHA-1s from DVE", e);
+        }
+
         try (var os = fileService.newOutputStream(versionInfoFile)) {
             mapper.writerWithDefaultPrettyPrinter().writeValue(os, root);
         }

--- a/src/main/java/nl/knaw/dans/transfer/core/SendToVaultTask.java
+++ b/src/main/java/nl/knaw/dans/transfer/core/SendToVaultTask.java
@@ -54,7 +54,7 @@ public class SendToVaultTask extends SourceDirItemProcessor implements Runnable 
     private final FileService fileService;
     private final DveMetadataReader dveMetadataReader;
     private final LobStoreClient lobStoreClient;
-    private final String datastation;
+    private final String datastationName;
     private final DependenciesReadyCheck readyCheck;
 
     private TransferItem currentTransferItem;
@@ -64,7 +64,7 @@ public class SendToVaultTask extends SourceDirItemProcessor implements Runnable 
         @NonNull DataVaultClient dataVaultClient, @NonNull String defaultMessage, @NonNull List<CustomPropertyConfig> customProperties, @NonNull FileService fileService,
         @NonNull DveMetadataReader dveMetadataReader,
         @NonNull LobStoreClient lobStoreClient,
-        @NonNull String datastation,
+        @NonNull String datastationName,
         @NonNull DependenciesReadyCheck readyCheck,
         long delayBetweenProcessingRounds) {
         super(srcDir, "DVE", new DveFileFilter().toPredicate(), CreationTimeComparator.getInstance(), fileService, delayBetweenProcessingRounds);
@@ -80,7 +80,7 @@ public class SendToVaultTask extends SourceDirItemProcessor implements Runnable 
         this.fileService = fileService;
         this.dveMetadataReader = dveMetadataReader;
         this.lobStoreClient = lobStoreClient;
-        this.datastation = datastation;
+        this.datastationName = datastationName;
         this.readyCheck = readyCheck;
     }
 
@@ -100,7 +100,7 @@ public class SendToVaultTask extends SourceDirItemProcessor implements Runnable 
         addToObjectImportDirectory(item, currentTransferItem.getOcflObjectVersion(), this.currentBatchWorkDir.resolve(currentTransferItem.getNbn()));
 
         var dveMetadata = dveMetadataReader.readDveMetadata(item);
-        var lobRequests = currentTransferItem.getLobRequests(dveMetadata, this.datastation);
+        var lobRequests = currentTransferItem.getLobRequests(dveMetadata, this.datastationName);
         if (!lobRequests.isEmpty()) {
             lobStoreClient.requestTransfers(lobRequests);
         }

--- a/src/main/java/nl/knaw/dans/transfer/core/SendToVaultTask.java
+++ b/src/main/java/nl/knaw/dans/transfer/core/SendToVaultTask.java
@@ -163,22 +163,23 @@ public class SendToVaultTask extends SourceDirItemProcessor implements Runnable 
                 value.ifPresent(v -> custom.put(name, v));
             }
         }
-        if (!custom.isEmpty()) {
-            root.put("object-version-properties", custom);
-        }
-
         try {
             var lobs = currentTransferItem.getFetchSha1s();
             if (lobs != null && !lobs.isEmpty()) {
                 Map<String, Object> externalLargeObjects = new HashMap<>();
                 externalLargeObjects.put("checksum-algorithm", "sha1");
                 externalLargeObjects.put("lobs", lobs);
-                root.put("external-large-objects", externalLargeObjects);
+                custom.put("external-large-objects", externalLargeObjects);
             }
         }
         catch (IOException e) {
             log.error("Failed to read fetch SHA-1s from DVE", e);
         }
+
+        if (!custom.isEmpty()) {
+            root.put("object-version-properties", custom);
+        }
+
 
         try (var os = fileService.newOutputStream(versionInfoFile)) {
             mapper.writerWithDefaultPrettyPrinter().writeValue(os, root);

--- a/src/main/java/nl/knaw/dans/transfer/core/SendToVaultTask.java
+++ b/src/main/java/nl/knaw/dans/transfer/core/SendToVaultTask.java
@@ -23,6 +23,7 @@ import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.lib.util.ZipUtil;
 import nl.knaw.dans.lib.util.healthcheck.DependenciesReadyCheck;
 import nl.knaw.dans.transfer.client.DataVaultClient;
+import nl.knaw.dans.transfer.client.LobStoreClient;
 import nl.knaw.dans.transfer.config.CustomPropertyConfig;
 import nl.knaw.dans.transfer.health.HealthChecks;
 import org.apache.commons.io.FileUtils;
@@ -51,6 +52,9 @@ public class SendToVaultTask extends SourceDirItemProcessor implements Runnable 
     private final String defaultMessage;
     private final List<CustomPropertyConfig> customProperties;
     private final FileService fileService;
+    private final DveMetadataReader dveMetadataReader;
+    private final LobStoreClient lobStoreClient;
+    private final String datastation;
     private final DependenciesReadyCheck readyCheck;
 
     private TransferItem currentTransferItem;
@@ -58,6 +62,9 @@ public class SendToVaultTask extends SourceDirItemProcessor implements Runnable 
     public SendToVaultTask(@NonNull Path srcDir, @NonNull Path currentBatchWorkDir, @NonNull Path dataVaultBatchRoot, @NonNull DataSize batchThreshold, @NonNull Path outboxProcessed,
         @NonNull Path outboxFailed,
         @NonNull DataVaultClient dataVaultClient, @NonNull String defaultMessage, @NonNull List<CustomPropertyConfig> customProperties, @NonNull FileService fileService,
+        @NonNull DveMetadataReader dveMetadataReader,
+        @NonNull LobStoreClient lobStoreClient,
+        @NonNull String datastation,
         @NonNull DependenciesReadyCheck readyCheck,
         long delayBetweenProcessingRounds) {
         super(srcDir, "DVE", new DveFileFilter().toPredicate(), CreationTimeComparator.getInstance(), fileService, delayBetweenProcessingRounds);
@@ -71,6 +78,9 @@ public class SendToVaultTask extends SourceDirItemProcessor implements Runnable 
         this.defaultMessage = defaultMessage;
         this.customProperties = customProperties;
         this.fileService = fileService;
+        this.dveMetadataReader = dveMetadataReader;
+        this.lobStoreClient = lobStoreClient;
+        this.datastation = datastation;
         this.readyCheck = readyCheck;
     }
 
@@ -86,11 +96,22 @@ public class SendToVaultTask extends SourceDirItemProcessor implements Runnable 
     @Override
     protected void processItem(@NonNull Path item) throws IOException {
         log.debug("Processing DVE {}", item);
-        currentTransferItem = new TransferItem(item, fileService);
+        currentTransferItem = createTransferItem(item);
         addToObjectImportDirectory(item, currentTransferItem.getOcflObjectVersion(), this.currentBatchWorkDir.resolve(currentTransferItem.getNbn()));
+
+        var dveMetadata = dveMetadataReader.readDveMetadata(item);
+        var lobRequests = currentTransferItem.getLobRequests(dveMetadata, this.datastation);
+        if (!lobRequests.isEmpty()) {
+            lobStoreClient.requestTransfers(lobRequests);
+        }
+
         log.info("Added {} to current batch", item.getFileName());
         importIfBatchThresholdReached();
         currentTransferItem.moveToDir(outboxProcessed, true);
+    }
+
+    TransferItem createTransferItem(Path item) throws IOException {
+        return new TransferItem(item, fileService);
     }
 
     @Override
@@ -112,7 +133,7 @@ public class SendToVaultTask extends SourceDirItemProcessor implements Runnable 
         }
     }
 
-    private void addToObjectImportDirectory(@NonNull Path dvePath, int ocflObjectVersionNumber, @NonNull Path objectImportDirectory) throws IOException {
+    void addToObjectImportDirectory(@NonNull Path dvePath, int ocflObjectVersionNumber, @NonNull Path objectImportDirectory) throws IOException {
         fileService.ensureDirectoryExists(objectImportDirectory);
         var versionDirectory = objectImportDirectory.resolve("v" + ocflObjectVersionNumber);
         log.debug("Extracting DVE {} to {}", dvePath, versionDirectory);
@@ -186,7 +207,7 @@ public class SendToVaultTask extends SourceDirItemProcessor implements Runnable 
         }
     }
 
-    private void importIfBatchThresholdReached() throws IOException {
+    void importIfBatchThresholdReached() throws IOException {
         if (sizeOfDirectory(this.currentBatchWorkDir.toFile()) > this.batchThreshold.toBytes()) {
             var batch = dataVaultBatchRoot.resolve("batch-" + System.currentTimeMillis());
             log.info("Batch threshold ({}) reached, sending batch {} to Data Vault", this.batchThreshold, batch);

--- a/src/main/java/nl/knaw/dans/transfer/core/SendToVaultTaskFactory.java
+++ b/src/main/java/nl/knaw/dans/transfer/core/SendToVaultTaskFactory.java
@@ -52,7 +52,7 @@ public class SendToVaultTaskFactory implements InboxTaskFactory {
     @NonNull
     private final LobStoreClient lobStoreClient;
     @NonNull
-    private final String datastation;
+    private final String datastationName;
     @NonNull
     private final DependenciesReadyCheck readyCheck;
     private final long delayBetweenProcessingRounds;
@@ -60,6 +60,6 @@ public class SendToVaultTaskFactory implements InboxTaskFactory {
     @Override
     public Runnable createInboxTask(Path path) {
         return new SendToVaultTask(path, currentBatchWorkDir, dataVaultBatchRoot, batchThreshold, outboxProcessed, outboxFailed, dataVaultClient, defaultMessage, customProperties, fileService,
-            dveMetadataReader, lobStoreClient, datastation, readyCheck, delayBetweenProcessingRounds);
+            dveMetadataReader, lobStoreClient, datastationName, readyCheck, delayBetweenProcessingRounds);
     }
 }

--- a/src/main/java/nl/knaw/dans/transfer/core/SendToVaultTaskFactory.java
+++ b/src/main/java/nl/knaw/dans/transfer/core/SendToVaultTaskFactory.java
@@ -21,6 +21,7 @@ import lombok.NonNull;
 import nl.knaw.dans.lib.util.healthcheck.DependenciesReadyCheck;
 import nl.knaw.dans.lib.util.inbox.InboxTaskFactory;
 import nl.knaw.dans.transfer.client.DataVaultClient;
+import nl.knaw.dans.transfer.client.LobStoreClient;
 import nl.knaw.dans.transfer.config.CustomPropertyConfig;
 
 import java.nio.file.Path;
@@ -47,11 +48,18 @@ public class SendToVaultTaskFactory implements InboxTaskFactory {
     @NonNull
     private final FileService fileService;
     @NonNull
+    private final DveMetadataReader dveMetadataReader;
+    @NonNull
+    private final LobStoreClient lobStoreClient;
+    @NonNull
+    private final String datastation;
+    @NonNull
     private final DependenciesReadyCheck readyCheck;
     private final long delayBetweenProcessingRounds;
 
     @Override
     public Runnable createInboxTask(Path path) {
-        return new SendToVaultTask(path, currentBatchWorkDir, dataVaultBatchRoot, batchThreshold, outboxProcessed, outboxFailed, dataVaultClient, defaultMessage, customProperties, fileService, readyCheck, delayBetweenProcessingRounds);
+        return new SendToVaultTask(path, currentBatchWorkDir, dataVaultBatchRoot, batchThreshold, outboxProcessed, outboxFailed, dataVaultClient, defaultMessage, customProperties, fileService,
+            dveMetadataReader, lobStoreClient, datastation, readyCheck, delayBetweenProcessingRounds);
     }
 }

--- a/src/main/java/nl/knaw/dans/transfer/core/TransferItem.java
+++ b/src/main/java/nl/knaw/dans/transfer/core/TransferItem.java
@@ -34,13 +34,17 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.file.Path;
 import java.nio.file.ProviderNotFoundException;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import nl.knaw.dans.lobstore.client.api.TransferRequestDto;
 
 /**
  * A Dataset Version Export (DVE) and auxiliary files. The DVE is the only mandatory file. The other files are searched next to the DVE or constructed from the DVE. This class is intended to provide
@@ -341,6 +345,40 @@ public class TransferItem {
         return cachedFetchSha1s;
     }
 
+    public List<TransferRequestDto> getLobRequests(DveMetadata metadata, String datastation) throws IOException {
+        var fetchSha1s = new HashSet<>(getFetchSha1s());
+        if (fetchSha1s.isEmpty()) {
+            return List.of();
+        }
+
+        return metadata.getDataFileAttributes().stream()
+            .filter(attr -> fetchSha1s.contains(attr.getSha1Checksum()))
+            .map(attr -> {
+                var uri = attr.getUri();
+                var query = uri.getQuery();
+                if (query == null) {
+                    throw new IllegalArgumentException("No query parameters found in URI: " + uri);
+                }
+                var fileIdStr = Arrays.stream(query.split("&"))
+                    .filter(s -> s.startsWith("fileId="))
+                    .map(s -> s.substring("fileId=".length()))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalArgumentException("No fileId found in URI: " + uri));
+
+                try {
+                    var fileId = Long.parseLong(fileIdStr);
+                    return new TransferRequestDto()
+                        .dataverseFileId(fileId)
+                        .sha1Sum(attr.getSha1Checksum())
+                        .datastation(datastation);
+                }
+                catch (NumberFormatException e) {
+                    throw new IllegalArgumentException("Invalid fileId found in URI: " + uri, e);
+                }
+            })
+            .toList();
+    }
+
     private List<String> readFetchSha1sUsingBagitLib(Path topLevelDir) {
         try {
             BagReader reader = new BagReader();
@@ -359,7 +397,7 @@ public class TransferItem {
                 .findFirst()
                 .map(m -> m.getFileToChecksumMap().entrySet().stream()
                     .filter(entry -> fetchPaths.contains(entry.getKey()))
-                    .map(java.util.Map.Entry::getValue)
+                    .map(Map.Entry::getValue)
                     .collect(Collectors.toCollection(TreeSet::new)))
                 .map(List::copyOf)
                 .orElse(List.of());

--- a/src/main/java/nl/knaw/dans/transfer/core/TransferItem.java
+++ b/src/main/java/nl/knaw/dans/transfer/core/TransferItem.java
@@ -19,17 +19,28 @@ import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.PathNotFoundException;
 import lombok.extern.slf4j.Slf4j;
+import nl.knaw.dans.bagit.domain.Bag;
+import nl.knaw.dans.bagit.domain.FetchItem;
+import nl.knaw.dans.bagit.exceptions.InvalidBagMetadataException;
 import nl.knaw.dans.bagit.exceptions.InvalidBagitFileFormatException;
 import nl.knaw.dans.bagit.exceptions.MaliciousPathException;
 import nl.knaw.dans.bagit.exceptions.UnparsableVersionException;
 import nl.knaw.dans.bagit.exceptions.UnsupportedAlgorithmException;
+import nl.knaw.dans.bagit.hash.StandardSupportedAlgorithms;
 import nl.knaw.dans.bagit.reader.BagReader;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.nio.file.Path;
 import java.nio.file.ProviderNotFoundException;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * A Dataset Version Export (DVE) and auxiliary files. The DVE is the only mandatory file. The other files are searched next to the DVE or constructed from the DVE. This class is intended to provide
@@ -44,6 +55,8 @@ public class TransferItem {
     private static final String DATAVERSE_WORK_STATUS_NAME_JSON_PATH = DATAVERSE_WORK_STATUS_JSON_PATH + "['schema:name']";
     private static final String DATAVERSE_DEACCESSIONED_REASON_JSON_PATH = DATAVERSE_WORK_STATUS_JSON_PATH + "['dvcore:reason']";
     private static final String HAS_ORGANIZATIONAL_IDENTIFIER_VERSION = "Has-Organizational-Identifier-Version";
+    private static final String FETCH_TXT = "fetch.txt";
+    private static final String MANIFEST_SHA1_TXT = "manifest-sha1.txt";
 
     private Path dve;
     private final FileService fileService;
@@ -60,6 +73,8 @@ public class TransferItem {
     private String cachedDataversePidVersion;
 
     private String cachedHasOrganizationalIdentifierVersion;
+
+    private List<String> cachedFetchSha1s;
 
     public TransferItem(Path dve, FileService fileService) {
         this.dve = dve;
@@ -317,5 +332,41 @@ public class TransferItem {
             readBagInfoFirstValue(topLevelDir, HAS_ORGANIZATIONAL_IDENTIFIER_VERSION)
         );
         cachedHasOrganizationalIdentifierVersion = opt.orElse(null);
+    }
+
+    public List<String> getFetchSha1s() throws IOException {
+        if (cachedFetchSha1s == null) {
+            cachedFetchSha1s = withTopLevelDir(this::readFetchSha1sUsingBagitLib);
+        }
+        return cachedFetchSha1s;
+    }
+
+    private List<String> readFetchSha1sUsingBagitLib(Path topLevelDir) {
+        try {
+            BagReader reader = new BagReader();
+            Bag bag = reader.read(topLevelDir);
+
+            Set<Path> fetchPaths = bag.getItemsToFetch().stream()
+                .map(FetchItem::getPath)
+                .collect(Collectors.toSet());
+
+            if (fetchPaths.isEmpty()) {
+                return List.of();
+            }
+
+            return bag.getPayLoadManifests().stream()
+                .filter(m -> m.getAlgorithm() == StandardSupportedAlgorithms.SHA1)
+                .findFirst()
+                .map(m -> m.getFileToChecksumMap().entrySet().stream()
+                    .filter(entry -> fetchPaths.contains(entry.getKey()))
+                    .map(java.util.Map.Entry::getValue)
+                    .collect(Collectors.toCollection(TreeSet::new)))
+                .map(List::copyOf)
+                .orElse(List.of());
+        }
+        catch (Exception e) {
+            log.error("Error reading bag with BagReader", e);
+            return List.of();
+        }
     }
 }

--- a/src/main/java/nl/knaw/dans/transfer/health/HealthChecks.java
+++ b/src/main/java/nl/knaw/dans/transfer/health/HealthChecks.java
@@ -21,4 +21,5 @@ public interface HealthChecks {
     String DATA_VAULT = "DataVault";
     String VALIDATE_BAG_PACK = "ValidateBagPack";
     String VAULT_CATALOG = "VaultCatalog";
+    String LOB_STORE = "LobStore";
 }

--- a/src/test/java/nl/knaw/dans/transfer/core/DataFileMetadataReaderTest.java
+++ b/src/test/java/nl/knaw/dans/transfer/core/DataFileMetadataReaderTest.java
@@ -15,120 +15,103 @@
  */
 package nl.knaw.dans.transfer.core;
 
+import nl.knaw.dans.transfer.TestDirFixture;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
+import org.junit.jupiter.api.io.TempDir;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
+import java.util.zip.ZipOutputStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class DataFileMetadataReaderTest {
+public class DataFileMetadataReaderTest extends TestDirFixture  {
 
     @Test
     void readDataFileAttributes_should_include_fetch_sizes() throws IOException {
         // Arrange
-        var fileService = mock(FileService.class);
+        var fileService = new FileServiceImpl(); // Use real implementation if possible, or mock only what's needed
         var reader = new DataFileMetadataReader(fileService);
-        var dveZip = Path.of("dve.zip");
-        var zipFile = mock(ZipFile.class);
-        
-        when(fileService.openZipFile(dveZip)).thenReturn(zipFile);
-        
-        String pidMapping = "doi:10.5072/FK2/FILE1 data/file1.txt\n" +
-                           "doi:10.5072/FK2/FILE2 data/file2.txt\n" +
-                           "doi:10.5072/FK2/FILE3 data/file3.txt\n";
-        String sha1Manifest = "sha1-file1 data/file1.txt\n" +
-                             "sha1-file2 data/file2.txt\n" +
-                             "sha1-file3 data/file3.txt\n";
-        String fetchTxt = "http://example.com/file1 100 data/file1.txt\n" +
-                          "http://example.com/file3 - data/file3.txt\n";
+        var dveZip = testDir.resolve("dve.zip");
 
-        when(fileService.getEntryUnderBaseFolder(zipFile, Path.of("metadata/pid-mapping.txt")))
-            .thenReturn(new ByteArrayInputStream(pidMapping.getBytes(StandardCharsets.UTF_8)));
-        when(fileService.getEntryUnderBaseFolder(zipFile, Path.of("manifest-sha1.txt")))
-            .thenReturn(new ByteArrayInputStream(sha1Manifest.getBytes(StandardCharsets.UTF_8)));
-        
-        // Mock fetch.txt exists
-        when(fileService.getEntryUnderBaseFolder(zipFile, Path.of("fetch.txt")))
-            .thenReturn(new ByteArrayInputStream(fetchTxt.getBytes(StandardCharsets.UTF_8)));
+        try (var zos = new ZipOutputStream(Files.newOutputStream(dveZip))) {
+            zos.putNextEntry(new ZipEntry("base/metadata/pid-mapping.txt"));
+            zos.write("doi:10.5072/FK2/FILE1 data/file1.txt\ndoi:10.5072/FK2/FILE2 data/file2.txt\ndoi:10.5072/FK2/FILE3 data/file3.txt\n".getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
 
-        // Mock zip entries for readPathToSizeMapping
-        var entry1 = mock(ZipEntry.class);
-        when(entry1.getName()).thenReturn("base/data/file1.txt");
-        when(entry1.getSize()).thenReturn(-1L);
-        when(entry1.isDirectory()).thenReturn(false);
+            zos.putNextEntry(new ZipEntry("base/bagit.txt"));
+            zos.write("BagIt-Version: 0.97\nTag-File-Character-Encoding: UTF-8\n".getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
 
-        var entry2 = mock(ZipEntry.class);
-        when(entry2.getName()).thenReturn("base/data/file2.txt");
-        when(entry2.getSize()).thenReturn(200L);
-        when(entry2.isDirectory()).thenReturn(false);
+            zos.putNextEntry(new ZipEntry("base/manifest-sha1.txt"));
+            zos.write("sha1-file1 data/file1.txt\nsha1-file2 data/file2.txt\nsha1-file3 data/file3.txt\n".getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
 
-        var entry3 = mock(ZipEntry.class);
-        when(entry3.getName()).thenReturn("base/data/file3.txt");
-        when(entry3.getSize()).thenReturn(-1L);
-        when(entry3.isDirectory()).thenReturn(false);
-        
-        when(zipFile.stream()).thenAnswer(i -> List.of(entry1, entry2, entry3).stream());
+            zos.putNextEntry(new ZipEntry("base/fetch.txt"));
+            zos.write("http://example.com/file1 100 data/file1.txt\nhttp://example.com/file3 - data/file3.txt\n".getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+
+            zos.putNextEntry(new ZipEntry("base/data/file2.txt"));
+            zos.write("content of file 2".getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+        }
 
         // Act
         List<DataFileMetadata> result = reader.readDataFileAttributes(dveZip);
 
         // Assert
         assertThat(result).hasSize(3);
-        
+
         var file1 = result.stream().filter(f -> f.getFilepath().toString().equals("data/file1.txt")).findFirst().get();
-        assertThat(file1.getSize()).isEqualTo(100L); // From fetch.txt
-        
+        assertThat(file1.getSize()).isEqualTo(100L);
+
         var file2 = result.stream().filter(f -> f.getFilepath().toString().equals("data/file2.txt")).findFirst().get();
-        assertThat(file2.getSize()).isEqualTo(200L); // From ZipEntry
+        assertThat(file2.getSize()).isEqualTo(17L); // "content of file 2".length()
 
         var file3 = result.stream().filter(f -> f.getFilepath().toString().equals("data/file3.txt")).findFirst().get();
-        assertThat(file3.getSize()).isEqualTo(-1L); // From fetch.txt with '-'
+        assertThat(file3.getSize()).isEqualTo(-1L);
     }
 
     @Test
     void readDataFileAttributes_should_work_without_fetch_txt() throws IOException {
         // Arrange
-        var fileService = mock(FileService.class);
+        var fileService = new FileServiceImpl();
         var reader = new DataFileMetadataReader(fileService);
-        var dveZip = Path.of("dve.zip");
-        var zipFile = mock(ZipFile.class);
-        
-        when(fileService.openZipFile(dveZip)).thenReturn(zipFile);
-        
-        String pidMapping = "doi:10.5072/FK2/FILE1 data/file1.txt\n";
-        String sha1Manifest = "sha1-file1 data/file1.txt\n";
+        var dveZip = testDir.resolve("dve_no_fetch.zip");
 
-        when(fileService.getEntryUnderBaseFolder(zipFile, Path.of("metadata/pid-mapping.txt")))
-            .thenReturn(new ByteArrayInputStream(pidMapping.getBytes(StandardCharsets.UTF_8)));
-        when(fileService.getEntryUnderBaseFolder(zipFile, Path.of("manifest-sha1.txt")))
-            .thenReturn(new ByteArrayInputStream(sha1Manifest.getBytes(StandardCharsets.UTF_8)));
-        
-        // Mock fetch.txt does NOT exist
-        when(fileService.getEntryUnderBaseFolder(zipFile, Path.of("fetch.txt")))
-            .thenThrow(new IllegalArgumentException("No entry found for path: fetch.txt"));
+        try (var zos = new ZipOutputStream(Files.newOutputStream(dveZip))) {
+            zos.putNextEntry(new ZipEntry("base/metadata/pid-mapping.txt"));
+            zos.write("doi:10.5072/FK2/FILE1 data/file1.txt\n".getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
 
-        var entry1 = new ZipEntry("base/data/file1.txt");
-        entry1.setSize(100);
-        when(zipFile.stream()).thenAnswer(i -> List.of(entry1).stream());
+            zos.putNextEntry(new ZipEntry("base/bagit.txt"));
+            zos.write("BagIt-Version: 0.97\nTag-File-Character-Encoding: UTF-8\n".getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+
+            zos.putNextEntry(new ZipEntry("base/manifest-sha1.txt"));
+            zos.write("sha1-file1 data/file1.txt\n".getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+
+            zos.putNextEntry(new ZipEntry("base/data/file1.txt"));
+            zos.write("content of file 1".getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+        }
 
         // Act
         List<DataFileMetadata> result = reader.readDataFileAttributes(dveZip);
 
         // Assert
         assertThat(result).hasSize(1);
-        assertThat(result.get(0).getSize()).isEqualTo(100L);
+        assertThat(result.get(0).getSize()).isEqualTo(17L);
+        assertThat(result.get(0).getFilepath().toString()).isEqualTo("data/file1.txt");
     }
 }

--- a/src/test/java/nl/knaw/dans/transfer/core/DataFileMetadataReaderTest.java
+++ b/src/test/java/nl/knaw/dans/transfer/core/DataFileMetadataReaderTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2025 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.transfer.core;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class DataFileMetadataReaderTest {
+
+    @Test
+    void readDataFileAttributes_should_include_fetch_sizes() throws IOException {
+        // Arrange
+        var fileService = mock(FileService.class);
+        var reader = new DataFileMetadataReader(fileService);
+        var dveZip = Path.of("dve.zip");
+        var zipFile = mock(ZipFile.class);
+        
+        when(fileService.openZipFile(dveZip)).thenReturn(zipFile);
+        
+        String pidMapping = "doi:10.5072/FK2/FILE1 data/file1.txt\n" +
+                           "doi:10.5072/FK2/FILE2 data/file2.txt\n" +
+                           "doi:10.5072/FK2/FILE3 data/file3.txt\n";
+        String sha1Manifest = "sha1-file1 data/file1.txt\n" +
+                             "sha1-file2 data/file2.txt\n" +
+                             "sha1-file3 data/file3.txt\n";
+        String fetchTxt = "http://example.com/file1 100 data/file1.txt\n" +
+                          "http://example.com/file3 - data/file3.txt\n";
+
+        when(fileService.getEntryUnderBaseFolder(zipFile, Path.of("metadata/pid-mapping.txt")))
+            .thenReturn(new ByteArrayInputStream(pidMapping.getBytes(StandardCharsets.UTF_8)));
+        when(fileService.getEntryUnderBaseFolder(zipFile, Path.of("manifest-sha1.txt")))
+            .thenReturn(new ByteArrayInputStream(sha1Manifest.getBytes(StandardCharsets.UTF_8)));
+        
+        // Mock fetch.txt exists
+        when(fileService.getEntryUnderBaseFolder(zipFile, Path.of("fetch.txt")))
+            .thenReturn(new ByteArrayInputStream(fetchTxt.getBytes(StandardCharsets.UTF_8)));
+
+        // Mock zip entries for readPathToSizeMapping
+        var entry1 = mock(ZipEntry.class);
+        when(entry1.getName()).thenReturn("base/data/file1.txt");
+        when(entry1.getSize()).thenReturn(-1L);
+        when(entry1.isDirectory()).thenReturn(false);
+
+        var entry2 = mock(ZipEntry.class);
+        when(entry2.getName()).thenReturn("base/data/file2.txt");
+        when(entry2.getSize()).thenReturn(200L);
+        when(entry2.isDirectory()).thenReturn(false);
+
+        var entry3 = mock(ZipEntry.class);
+        when(entry3.getName()).thenReturn("base/data/file3.txt");
+        when(entry3.getSize()).thenReturn(-1L);
+        when(entry3.isDirectory()).thenReturn(false);
+        
+        when(zipFile.stream()).thenAnswer(i -> List.of(entry1, entry2, entry3).stream());
+
+        // Act
+        List<DataFileMetadata> result = reader.readDataFileAttributes(dveZip);
+
+        // Assert
+        assertThat(result).hasSize(3);
+        
+        var file1 = result.stream().filter(f -> f.getFilepath().toString().equals("data/file1.txt")).findFirst().get();
+        assertThat(file1.getSize()).isEqualTo(100L); // From fetch.txt
+        
+        var file2 = result.stream().filter(f -> f.getFilepath().toString().equals("data/file2.txt")).findFirst().get();
+        assertThat(file2.getSize()).isEqualTo(200L); // From ZipEntry
+
+        var file3 = result.stream().filter(f -> f.getFilepath().toString().equals("data/file3.txt")).findFirst().get();
+        assertThat(file3.getSize()).isEqualTo(-1L); // From fetch.txt with '-'
+    }
+
+    @Test
+    void readDataFileAttributes_should_work_without_fetch_txt() throws IOException {
+        // Arrange
+        var fileService = mock(FileService.class);
+        var reader = new DataFileMetadataReader(fileService);
+        var dveZip = Path.of("dve.zip");
+        var zipFile = mock(ZipFile.class);
+        
+        when(fileService.openZipFile(dveZip)).thenReturn(zipFile);
+        
+        String pidMapping = "doi:10.5072/FK2/FILE1 data/file1.txt\n";
+        String sha1Manifest = "sha1-file1 data/file1.txt\n";
+
+        when(fileService.getEntryUnderBaseFolder(zipFile, Path.of("metadata/pid-mapping.txt")))
+            .thenReturn(new ByteArrayInputStream(pidMapping.getBytes(StandardCharsets.UTF_8)));
+        when(fileService.getEntryUnderBaseFolder(zipFile, Path.of("manifest-sha1.txt")))
+            .thenReturn(new ByteArrayInputStream(sha1Manifest.getBytes(StandardCharsets.UTF_8)));
+        
+        // Mock fetch.txt does NOT exist
+        when(fileService.getEntryUnderBaseFolder(zipFile, Path.of("fetch.txt")))
+            .thenThrow(new IllegalArgumentException("No entry found for path: fetch.txt"));
+
+        var entry1 = new ZipEntry("base/data/file1.txt");
+        entry1.setSize(100);
+        when(zipFile.stream()).thenAnswer(i -> List.of(entry1).stream());
+
+        // Act
+        List<DataFileMetadata> result = reader.readDataFileAttributes(dveZip);
+
+        // Assert
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getSize()).isEqualTo(100L);
+    }
+}

--- a/src/test/java/nl/knaw/dans/transfer/core/DveMetadataReaderTest.java
+++ b/src/test/java/nl/knaw/dans/transfer/core/DveMetadataReaderTest.java
@@ -66,7 +66,6 @@ public class DveMetadataReaderTest {
             .otherIdVersion("1")
             .swordToken("token")
             .dataSupplier("supplier")
-            .datastation("station")
             .exporter("exporter")
             .exporterVersion("1.0")
             .build();

--- a/src/test/java/nl/knaw/dans/transfer/core/DveMetadataReaderTest.java
+++ b/src/test/java/nl/knaw/dans/transfer/core/DveMetadataReaderTest.java
@@ -73,7 +73,7 @@ public class DveMetadataReaderTest {
         when(oaiReader.readMetadata(anyString())).thenReturn(baseMetadata);
 
         var dfList = List.of(new DataFileMetadata(
-            Path.of("data/file1.txt"),
+            "data/file1.txt",
             URI.create("https://doi.org/10.5072/FK2/FILE1"),
             "abc123",
             123L

--- a/src/test/java/nl/knaw/dans/transfer/core/ExtractMetadataTaskTest.java
+++ b/src/test/java/nl/knaw/dans/transfer/core/ExtractMetadataTaskTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2025 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.transfer.core;
+
+import nl.knaw.dans.lib.util.healthcheck.DependenciesReadyCheck;
+import nl.knaw.dans.transfer.TestDirFixture;
+import nl.knaw.dans.transfer.client.ValidateBagPackClient;
+import nl.knaw.dans.transfer.client.VaultCatalogClient;
+import nl.knaw.dans.transfer.config.ValidateBagPackConfig;
+import nl.knaw.dans.validatebagpack.client.api.ValidationResultDto;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class ExtractMetadataTaskTest extends TestDirFixture {
+
+    @Test
+    public void processItem_should_throw_IllegalArgumentException_when_holey_bag_and_datastationName_is_null() throws Exception {
+        // Given
+        var srcDir = testDir.resolve("src");
+        var outboxProcessed = testDir.resolve("processed");
+        var outboxFailed = testDir.resolve("failed");
+        var outboxRejected = testDir.resolve("rejected");
+        var nbnRegistrationInbox = testDir.resolve("nbn-inbox");
+        var vaultCatalogBaseUri = URI.create("http://localhost/catalog");
+        var dveMetadataReader = Mockito.mock(DveMetadataReader.class);
+        var fileService = Mockito.mock(FileService.class);
+        var vaultCatalogClient = Mockito.mock(VaultCatalogClient.class);
+        var validateBagPackClient = Mockito.mock(ValidateBagPackClient.class);
+        var readyCheck = Mockito.mock(DependenciesReadyCheck.class);
+
+        // Mock TransferItem to return non-empty fetch sha1s
+        var transferItem = Mockito.mock(TransferItem.class);
+        Mockito.when(transferItem.getFetchSha1s()).thenReturn(List.of("sha1"));
+
+        var task = new ExtractMetadataTask(
+            srcDir, null, outboxProcessed, outboxFailed, outboxRejected,
+            nbnRegistrationInbox, vaultCatalogBaseUri, dveMetadataReader, fileService,
+            vaultCatalogClient, validateBagPackClient, readyCheck, 100
+        ) {
+            @Override
+            protected TransferItem createTransferItem(Path item) {
+                return transferItem;
+            }
+        };
+
+        var item = srcDir.resolve("dataset.zip");
+        
+        // Mock validateBagPackClient to return success
+        var result = Mockito.mock(ValidationResultDto.class);
+        Mockito.when(result.getIsCompliant()).thenReturn(true);
+        Mockito.when(validateBagPackClient.validateBagPack(item)).thenReturn(result);
+
+        // When / Then
+        assertThatThrownBy(() -> task.processItem(item))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Holey bags (with fetch.txt) are not supported for VaaS customers yet.");
+    }
+}

--- a/src/test/java/nl/knaw/dans/transfer/core/SendToVaultTaskTest.java
+++ b/src/test/java/nl/knaw/dans/transfer/core/SendToVaultTaskTest.java
@@ -247,7 +247,9 @@ public class SendToVaultTaskTest extends TestDirFixture {
         try (var is = Files.newInputStream(jsonFile)) {
             root = mapper.readValue(is, Map.class);
         }
-        Map<?,?> externalLargeObjects = (Map<?,?>) root.get("external-large-objects");
+        Map<?,?> objectVersionProperties = (Map<?,?>) root.get("object-version-properties");
+        assertThat(objectVersionProperties).isNotNull();
+        Map<?,?> externalLargeObjects = (Map<?,?>) objectVersionProperties.get("external-large-objects");
         assertThat(externalLargeObjects).isNotNull();
         assertThat(externalLargeObjects.get("checksum-algorithm")).isEqualTo("sha1");
         assertThat((List<String>) externalLargeObjects.get("lobs")).containsExactlyInAnyOrder("sha1-1", "sha1-2");

--- a/src/test/java/nl/knaw/dans/transfer/core/SendToVaultTaskTest.java
+++ b/src/test/java/nl/knaw/dans/transfer/core/SendToVaultTaskTest.java
@@ -19,14 +19,18 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.util.DataSize;
 import nl.knaw.dans.lib.util.ZipUtil;
 import nl.knaw.dans.lib.util.healthcheck.DependenciesReadyCheck;
+import nl.knaw.dans.lobstore.client.api.TransferRequestDto;
 import nl.knaw.dans.transfer.TestDirFixture;
 import nl.knaw.dans.transfer.client.DataVaultClient;
+import nl.knaw.dans.transfer.client.LobStoreClient;
 import nl.knaw.dans.transfer.config.CustomPropertyConfig;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.lang.reflect.InvocationTargetException;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -46,13 +50,15 @@ public class SendToVaultTaskTest extends TestDirFixture {
         var outboxFailed = testDir.resolve("failed");
         var dataVaultClient = Mockito.mock(DataVaultClient.class);
         var fileService = new FileServiceImpl();
+        var dveMetadataReader = Mockito.mock(DveMetadataReader.class);
+        var lobStoreClient = Mockito.mock(LobStoreClient.class);
         var readyCheck = Mockito.mock(DependenciesReadyCheck.class);
         var defaultMessage = "msg";
         var customProperties = new ArrayList<CustomPropertyConfig>();
 
         var task = new SendToVaultTask(
             dve, currentBatchWorkDir, dataVaultBatchRoot, DataSize.bytes(0), outboxProcessed, outboxFailed,
-            dataVaultClient, defaultMessage, customProperties, fileService, readyCheck, 100
+            dataVaultClient, defaultMessage, customProperties, fileService, dveMetadataReader, lobStoreClient, "ds1", readyCheck, 100
         );
 
         // Prepare object import directory with two versions
@@ -107,13 +113,15 @@ public class SendToVaultTaskTest extends TestDirFixture {
         Path outboxFailed = testDir.resolve("failed");
         DataVaultClient dataVaultClient = Mockito.mock(DataVaultClient.class);
         FileService fileService = new FileServiceImpl();
+        DveMetadataReader dveMetadataReader = Mockito.mock(DveMetadataReader.class);
+        LobStoreClient lobStoreClient = Mockito.mock(LobStoreClient.class);
         DependenciesReadyCheck readyCheck = Mockito.mock(DependenciesReadyCheck.class);
         String defaultMessage = "Default message with\nnewline";
         List<CustomPropertyConfig> customProperties = new ArrayList<>();
 
         var task = new SendToVaultTask(
             dve, currentBatchWorkDir, dataVaultBatchRoot, DataSize.bytes(0), outboxProcessed, outboxFailed,
-            dataVaultClient, defaultMessage, customProperties, fileService, readyCheck, 100
+            dataVaultClient, defaultMessage, customProperties, fileService, dveMetadataReader, lobStoreClient, "ds1", readyCheck, 100
         );
 
         // Set up a TransferItem
@@ -159,13 +167,15 @@ public class SendToVaultTaskTest extends TestDirFixture {
         Path outboxFailed = testDir.resolve("failed");
         DataVaultClient dataVaultClient = Mockito.mock(DataVaultClient.class);
         FileService fileService = new FileServiceImpl();
+        DveMetadataReader dveMetadataReader = Mockito.mock(DveMetadataReader.class);
+        LobStoreClient lobStoreClient = Mockito.mock(LobStoreClient.class);
         DependenciesReadyCheck readyCheck = Mockito.mock(DependenciesReadyCheck.class);
         String defaultMessage = "msg";
         List<CustomPropertyConfig> customProperties = new ArrayList<>();
 
         var task = new SendToVaultTask(
             dve, currentBatchWorkDir, dataVaultBatchRoot, DataSize.bytes(0), outboxProcessed, outboxFailed,
-            dataVaultClient, defaultMessage, customProperties, fileService, readyCheck, 100
+            dataVaultClient, defaultMessage, customProperties, fileService, dveMetadataReader, lobStoreClient, "ds1", readyCheck, 100
         );
 
         // Prepare version directory
@@ -215,13 +225,15 @@ public class SendToVaultTaskTest extends TestDirFixture {
         Path outboxFailed = testDir.resolve("failed");
         DataVaultClient dataVaultClient = Mockito.mock(DataVaultClient.class);
         FileService fileService = new FileServiceImpl();
+        DveMetadataReader dveMetadataReader = Mockito.mock(DveMetadataReader.class);
+        LobStoreClient lobStoreClient = Mockito.mock(LobStoreClient.class);
         DependenciesReadyCheck readyCheck = Mockito.mock(DependenciesReadyCheck.class);
         String defaultMessage = "msg";
         List<CustomPropertyConfig> customProperties = new ArrayList<>();
 
         var task = new SendToVaultTask(
             dve, currentBatchWorkDir, dataVaultBatchRoot, DataSize.bytes(0), outboxProcessed, outboxFailed,
-            dataVaultClient, defaultMessage, customProperties, fileService, readyCheck, 100
+            dataVaultClient, defaultMessage, customProperties, fileService, dveMetadataReader, lobStoreClient, "ds1", readyCheck, 100
         );
 
         Path versionDirectory = testDir.resolve("v1");
@@ -253,5 +265,111 @@ public class SendToVaultTaskTest extends TestDirFixture {
         assertThat(externalLargeObjects).isNotNull();
         assertThat(externalLargeObjects.get("checksum-algorithm")).isEqualTo("sha1");
         assertThat((List<String>) externalLargeObjects.get("lobs")).containsExactlyInAnyOrder("sha1-1", "sha1-2");
+    }
+
+    @Test
+    public void processItem_should_request_transfers_from_lob_store_when_lobs_present() throws Exception {
+        // Given
+        Path item = testDir.resolve("test.zip");
+        Files.createFile(item);
+        Path currentBatchWorkDir = testDir.resolve("batch");
+        Files.createDirectories(currentBatchWorkDir);
+        Path dataVaultBatchRoot = testDir.resolve("vault");
+        Path outboxProcessed = testDir.resolve("processed");
+        Files.createDirectories(outboxProcessed);
+        Path outboxFailed = testDir.resolve("failed");
+        DataVaultClient dataVaultClient = Mockito.mock(DataVaultClient.class);
+        FileService fileService = Mockito.mock(FileService.class);
+        DveMetadataReader dveMetadataReader = Mockito.mock(DveMetadataReader.class);
+        LobStoreClient lobStoreClient = Mockito.mock(LobStoreClient.class);
+        DependenciesReadyCheck readyCheck = Mockito.mock(DependenciesReadyCheck.class);
+
+        var task = Mockito.spy(new SendToVaultTask(
+            testDir, currentBatchWorkDir, dataVaultBatchRoot, DataSize.bytes(1000), outboxProcessed, outboxFailed,
+            dataVaultClient, "msg", List.of(), fileService, dveMetadataReader, lobStoreClient, "ds1", readyCheck, 100
+        ));
+
+        DveMetadata metadata = Mockito.mock(DveMetadata.class);
+        DataFileMetadata attr = Mockito.mock(DataFileMetadata.class);
+        Mockito.when(attr.getSha1Checksum()).thenReturn("sha1");
+        Mockito.when(attr.getUri()).thenReturn(new URI("http://dv.com/file/?fileId=123"));
+        Mockito.when(metadata.getDataFileAttributes()).thenReturn(List.of(attr));
+
+        Mockito.when(dveMetadataReader.readDveMetadata(item)).thenReturn(metadata);
+
+        // Mock TransferItem
+        TransferItem transferItem = Mockito.mock(TransferItem.class);
+        Mockito.when(transferItem.getNbn()).thenReturn("nbn1");
+        Mockito.when(transferItem.getOcflObjectVersion()).thenReturn(1);
+        Mockito.when(transferItem.getFetchSha1s()).thenReturn(List.of("sha1"));
+
+        // Use the real getLobRequests but with mocked metadata
+        Mockito.when(transferItem.getLobRequests(Mockito.any(), Mockito.anyString())).thenCallRealMethod();
+
+        // Inject TransferItem into task
+        Mockito.doReturn(transferItem).when(task).createTransferItem(item);
+        Mockito.doNothing().when(task).addToObjectImportDirectory(Mockito.any(), Mockito.anyInt(), Mockito.any());
+        Mockito.doNothing().when(task).importIfBatchThresholdReached();
+
+        // When
+        task.processItem(item);
+
+        // Then
+        ArgumentCaptor<List<TransferRequestDto>> captor = ArgumentCaptor.forClass(List.class);
+        Mockito.verify(lobStoreClient).requestTransfers(captor.capture());
+        List<TransferRequestDto> requests = captor.getValue();
+        assertThat(requests).hasSize(1);
+        assertThat(requests.get(0).getDataverseFileId()).isEqualTo(123L);
+        assertThat(requests.get(0).getSha1Sum()).isEqualTo("sha1");
+        assertThat(requests.get(0).getDatastation()).isEqualTo("ds1");
+    }
+
+    @Test
+    public void processItem_should_fail_when_fileId_is_missing_in_uri() throws Exception {
+        // Given
+        Path item = testDir.resolve("test.zip");
+        Files.createFile(item);
+        Path currentBatchWorkDir = testDir.resolve("batch");
+        Files.createDirectories(currentBatchWorkDir);
+        Path dataVaultBatchRoot = testDir.resolve("vault");
+        Path outboxProcessed = testDir.resolve("processed");
+        Path outboxFailed = testDir.resolve("failed");
+        DataVaultClient dataVaultClient = Mockito.mock(DataVaultClient.class);
+        FileService fileService = Mockito.mock(FileService.class);
+        DveMetadataReader dveMetadataReader = Mockito.mock(DveMetadataReader.class);
+        LobStoreClient lobStoreClient = Mockito.mock(LobStoreClient.class);
+        DependenciesReadyCheck readyCheck = Mockito.mock(DependenciesReadyCheck.class);
+
+        var task = Mockito.spy(new SendToVaultTask(
+            testDir, currentBatchWorkDir, dataVaultBatchRoot, DataSize.bytes(1000), outboxProcessed, outboxFailed,
+            dataVaultClient, "msg", List.of(), fileService, dveMetadataReader, lobStoreClient, "ds1", readyCheck, 100
+        ));
+
+        DveMetadata metadata = Mockito.mock(DveMetadata.class);
+        DataFileMetadata attr = Mockito.mock(DataFileMetadata.class);
+        Mockito.when(attr.getSha1Checksum()).thenReturn("sha1");
+        Mockito.when(attr.getUri()).thenReturn(new URI("http://dv.com/file/?otherId=123"));
+        Mockito.when(metadata.getDataFileAttributes()).thenReturn(List.of(attr));
+
+        Mockito.when(dveMetadataReader.readDveMetadata(item)).thenReturn(metadata);
+
+        TransferItem transferItem = Mockito.mock(TransferItem.class);
+        Mockito.when(transferItem.getNbn()).thenReturn("nbn1");
+        Mockito.when(transferItem.getOcflObjectVersion()).thenReturn(1);
+        Mockito.when(transferItem.getFetchSha1s()).thenReturn(List.of("sha1"));
+        Mockito.when(transferItem.getLobRequests(Mockito.any(), Mockito.anyString())).thenCallRealMethod();
+
+        Mockito.doReturn(transferItem).when(task).createTransferItem(item);
+        Mockito.doNothing().when(task).addToObjectImportDirectory(Mockito.any(), Mockito.anyInt(), Mockito.any());
+
+        // When
+        try {
+            task.processItem(item);
+        } catch (IllegalArgumentException e) {
+            task.rejectCurrentItem(e);
+        }
+
+        // Then
+        Mockito.verify(transferItem).moveToErrorBox(Mockito.eq(outboxFailed), Mockito.any(IllegalArgumentException.class));
     }
 }

--- a/src/test/java/nl/knaw/dans/transfer/core/SendToVaultTaskTest.java
+++ b/src/test/java/nl/knaw/dans/transfer/core/SendToVaultTaskTest.java
@@ -116,6 +116,13 @@ public class SendToVaultTaskTest extends TestDirFixture {
             dataVaultClient, defaultMessage, customProperties, fileService, readyCheck, 100
         );
 
+        // Set up a TransferItem
+        var transferItem = Mockito.mock(TransferItem.class);
+        Mockito.when(transferItem.getFetchSha1s()).thenReturn(List.of());
+        var field = SendToVaultTask.class.getDeclaredField("currentTransferItem");
+        field.setAccessible(true);
+        field.set(task, transferItem);
+
         Path versionDirectory = testDir.resolve("v1");
         Files.createDirectories(versionDirectory);
 
@@ -197,5 +204,52 @@ public class SendToVaultTaskTest extends TestDirFixture {
             // Directory should be deleted (parent or version dir)
             assertThat(Files.exists(objectImportDirectory)).isFalse();
         }
+    }
+    @Test
+    public void createVersionInfoJson_should_include_external_large_objects_when_fetch_sha1s_present() throws Exception {
+        // Given
+        Path dve = testDir.resolve("test.zip");
+        Path currentBatchWorkDir = testDir.resolve("batch");
+        Path dataVaultBatchRoot = testDir.resolve("vault");
+        Path outboxProcessed = testDir.resolve("processed");
+        Path outboxFailed = testDir.resolve("failed");
+        DataVaultClient dataVaultClient = Mockito.mock(DataVaultClient.class);
+        FileService fileService = new FileServiceImpl();
+        DependenciesReadyCheck readyCheck = Mockito.mock(DependenciesReadyCheck.class);
+        String defaultMessage = "msg";
+        List<CustomPropertyConfig> customProperties = new ArrayList<>();
+
+        var task = new SendToVaultTask(
+            dve, currentBatchWorkDir, dataVaultBatchRoot, DataSize.bytes(0), outboxProcessed, outboxFailed,
+            dataVaultClient, defaultMessage, customProperties, fileService, readyCheck, 100
+        );
+
+        Path versionDirectory = testDir.resolve("v1");
+        Files.createDirectories(versionDirectory);
+
+        // Set up a TransferItem with fetch sha1s
+        var transferItem = Mockito.mock(TransferItem.class);
+        Mockito.when(transferItem.getFetchSha1s()).thenReturn(List.of("sha1-1", "sha1-2"));
+        // Set currentTransferItem via reflection
+        var field = SendToVaultTask.class.getDeclaredField("currentTransferItem");
+        field.setAccessible(true);
+        field.set(task, transferItem);
+
+        // When
+        task.createVersionInfoJson(versionDirectory, "user", "email", "message");
+
+        // Then
+        Path jsonFile = testDir.resolve("v1.json");
+        assertThat(jsonFile).exists();
+
+        var mapper = new ObjectMapper();
+        Map<?,?> root;
+        try (var is = Files.newInputStream(jsonFile)) {
+            root = mapper.readValue(is, Map.class);
+        }
+        Map<?,?> externalLargeObjects = (Map<?,?>) root.get("external-large-objects");
+        assertThat(externalLargeObjects).isNotNull();
+        assertThat(externalLargeObjects.get("checksum-algorithm")).isEqualTo("sha1");
+        assertThat((List<String>) externalLargeObjects.get("lobs")).containsExactlyInAnyOrder("sha1-1", "sha1-2");
     }
 }

--- a/src/test/java/nl/knaw/dans/transfer/core/TransferItemTest.java
+++ b/src/test/java/nl/knaw/dans/transfer/core/TransferItemTest.java
@@ -302,6 +302,46 @@ public class TransferItemTest extends TestDirFixture {
         assertThat(item2.getDeaccessionedReason()).isEmpty();
     }
 
+    @Test
+    public void getFetchSha1s_should_return_sha1s_from_manifest_for_files_in_fetch_txt() throws Exception {
+        // Given
+        var sourceDir = testDir.resolve("transfer-item-fetch");
+        Files.createDirectories(sourceDir);
+        var dve = sourceDir.resolve("dataset_v1.zip");
+        var fetchTxt = "http://example.com/file1 100 data/file1\n" +
+                       "http://example.com/file2 200 data/file2\n";
+        var manifestSha1 = "sha1-value-1  data/file1\n" +
+                           "sha1-value-2  data/file2\n" +
+                           "sha1-value-3  data/file3\n";
+        createDveZip(dve, null, null, "urn:nbn:nl:ui:13-fetch", null, null, null, null, fetchTxt, manifestSha1);
+
+        var item = new TransferItem(dve, fileService);
+
+        // When
+        var sha1s = item.getFetchSha1s();
+
+        // Then
+        assertThat(sha1s).containsExactlyInAnyOrder("sha1-value-1", "sha1-value-2");
+    }
+
+    @Test
+    public void getFetchSha1s_should_return_empty_list_when_fetch_txt_missing() throws Exception {
+        // Given
+        var sourceDir = testDir.resolve("transfer-item-no-fetch");
+        Files.createDirectories(sourceDir);
+        var dve = sourceDir.resolve("dataset_v1.zip");
+        var manifestSha1 = "sha1-value-1  data/file1\n";
+        createDveZip(dve, null, null, "urn:nbn:nl:ui:13-no-fetch", null, null, null, null, null, manifestSha1);
+
+        var item = new TransferItem(dve, fileService);
+
+        // When
+        var sha1s = item.getFetchSha1s();
+
+        // Then
+        assertThat(sha1s).isEmpty();
+    }
+
 
     /**
      * Helper method to create a DVE zip file for testing purposes. Creates a minimal BagIt structure with bag-info.txt containing contact information and optionally an oai-ore.jsonld metadata file
@@ -316,11 +356,16 @@ public class TransferItemTest extends TestDirFixture {
      * @throws IOException if an I/O error occurs during zip creation
      */
     private static void createDveZip(Path zipPath, String contactName, String contactEmail, String nbn, String pidVersion, String hasOrganizationalIdentifierVersion) throws IOException {
-        createDveZip(zipPath, contactName, contactEmail, nbn, pidVersion, hasOrganizationalIdentifierVersion, null, null);
+        createDveZip(zipPath, contactName, contactEmail, nbn, pidVersion, hasOrganizationalIdentifierVersion, null, null, null, null);
     }
 
     private static void createDveZip(Path zipPath, String contactName, String contactEmail, String nbn, String pidVersion, String hasOrganizationalIdentifierVersion,
                                      String creativeWorkStatusName, String deaccessionReason) throws IOException {
+        createDveZip(zipPath, contactName, contactEmail, nbn, pidVersion, hasOrganizationalIdentifierVersion, creativeWorkStatusName, deaccessionReason, null, null);
+    }
+
+    private static void createDveZip(Path zipPath, String contactName, String contactEmail, String nbn, String pidVersion, String hasOrganizationalIdentifierVersion,
+                                     String creativeWorkStatusName, String deaccessionReason, String fetchTxt, String manifestSha1) throws IOException {
         var env = new HashMap<String, String>();
         env.put("create", "true");
         try (var zipfs = FileSystems.newFileSystem(URI.create("jar:" + zipPath.toUri()), env)) {
@@ -342,6 +387,13 @@ public class TransferItemTest extends TestDirFixture {
                 bagInfo.append("Has-Organizational-Identifier-Version: ").append(hasOrganizationalIdentifierVersion).append("\n");
             }
             Files.writeString(top.resolve("bag-info.txt"), bagInfo.toString(), StandardCharsets.UTF_8);
+
+            if (fetchTxt != null) {
+                Files.writeString(top.resolve("fetch.txt"), fetchTxt, StandardCharsets.UTF_8);
+            }
+            if (manifestSha1 != null) {
+                Files.writeString(top.resolve("manifest-sha1.txt"), manifestSha1, StandardCharsets.UTF_8);
+            }
 
             if (nbn != null || pidVersion != null || creativeWorkStatusName != null) {
                 var metadataDir = Files.createDirectories(top.resolve("metadata"));

--- a/src/test/resources/debug-etc/config.yml
+++ b/src/test/resources/debug-etc/config.yml
@@ -20,7 +20,7 @@ server:
 
 transfer:
   workspaceFreeSpaceThreshold: 1GB
-  ocflStorageRoot: Test Datastation
+  datastationName: Test Datastation
   # Inbox for incoming DVEs
   collectDve:
     inbox:

--- a/src/test/resources/debug-etc/config.yml
+++ b/src/test/resources/debug-etc/config.yml
@@ -102,6 +102,11 @@ health:
       initialState: false
       schedule:
         checkInterval: 60s
+    - name: LobStore
+      critical: true
+      initialState: false
+      schedule:
+        checkInterval: 60s
   initialOverallState: false
 
 readyCheck:
@@ -110,6 +115,7 @@ readyCheck:
     - VaultCatalog
     - DataVault
     - ValidateBagPack
+    - LobStore
     - FileSystemFreeSpace
   pollInterval: 5s
 
@@ -148,6 +154,16 @@ dataVault:
 validateBagPack:
   url: http://localhost:20375
   pingUrl: http://localhost:20376/ping
+  httpClient:
+    timeout: 30s
+    connectionTimeout: 15s
+    timeToLive: 1h
+    retries: 2
+    userAgent: dd-transfer-to-vault
+
+lobStore:
+  url: http://localhost:20385
+  pingUrl: http://localhost:20386/ping
   httpClient:
     timeout: 30s
     connectionTimeout: 15s


### PR DESCRIPTION
Fixes DD-2235

# Description of changes
* For files that are included by `fetch.txt` reference the size cannot be determined from the entry length, so the size provided in `fetch.txt` itself must be used for the information sent to the Vault Catalog.
* `SendToVaultTask` now sets the `external-large-objects` object version property if there is a `fetch.txt` file in the BagPack (i.e. when it is a "holey" bag).
* `SendToVaultTask` also sends a request to `dd-lob-store` to get those files and store them in the LOB store for the Data Station / OCFL storage root associated with the pipeline.


# Notify
@DANS-KNAW/core-systems
