### PR TITLE
DD-2373 handle N/A Contact-Email

### DIFF
--- a/src/main/java/nl/knaw/dans/transfer/core/TransferItem.java
+++ b/src/main/java/nl/knaw/dans/transfer/core/TransferItem.java
@@ -271,11 +271,15 @@ public class TransferItem {
         withTopLevelDir(topLevelDir -> {
             try {
                 var metadata = new BagReader().read(topLevelDir).getMetadata();
+                final var defaultEmail = "no.email@dummy.org";
 
                 cachedContactEmail = getFirstValue(metadata, "Contact-Email")
-                    .filter(s -> !s.equalsIgnoreCase("N/A"))
-                    .or(() -> getFirstValue(metadata, "Organization-Email"))
-                    .orElse("no.email@dummy.org");
+                    .map(String::trim)
+                    .filter(s -> !s.isBlank() && !s.equalsIgnoreCase("N/A"))
+                    .or(() -> getFirstValue(metadata, "Organization-Email")
+                        .map(String::trim)
+                        .filter(s -> !s.isBlank() && !s.equalsIgnoreCase("N/A")))
+                    .orElse(defaultEmail);
 
                 cachedContactName = getFirstValue(metadata, "Contact-Name")
                     .filter(s -> !s.isBlank())

--- a/src/main/java/nl/knaw/dans/transfer/core/TransferItem.java
+++ b/src/main/java/nl/knaw/dans/transfer/core/TransferItem.java
@@ -21,30 +21,27 @@ import com.jayway.jsonpath.PathNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.bagit.domain.Bag;
 import nl.knaw.dans.bagit.domain.FetchItem;
-import nl.knaw.dans.bagit.exceptions.InvalidBagMetadataException;
+import nl.knaw.dans.bagit.domain.Metadata;
 import nl.knaw.dans.bagit.exceptions.InvalidBagitFileFormatException;
 import nl.knaw.dans.bagit.exceptions.MaliciousPathException;
 import nl.knaw.dans.bagit.exceptions.UnparsableVersionException;
 import nl.knaw.dans.bagit.exceptions.UnsupportedAlgorithmException;
 import nl.knaw.dans.bagit.hash.StandardSupportedAlgorithms;
 import nl.knaw.dans.bagit.reader.BagReader;
+import nl.knaw.dans.lobstore.client.api.TransferRequestDto;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.nio.file.Path;
 import java.nio.file.ProviderNotFoundException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import nl.knaw.dans.lobstore.client.api.TransferRequestDto;
 
 /**
  * A Dataset Version Export (DVE) and auxiliary files. The DVE is the only mandatory file. The other files are searched next to the DVE or constructed from the DVE. This class is intended to provide
@@ -188,11 +185,7 @@ public class TransferItem {
     private Optional<String> readBagInfoFirstValue(Path topLevelDir, String key) {
         try {
             var bag = new BagReader().read(topLevelDir);
-            var values = bag.getMetadata().get(key);
-            if (values != null && !values.isEmpty()) {
-                return Optional.ofNullable(values.get(0));
-            }
-            return Optional.empty();
+            return getFirstValue(bag.getMetadata(), key);
         }
         catch (IOException e) {
             throw new RuntimeException("Unable to read bag from DVE: " + dve, e);
@@ -203,6 +196,11 @@ public class TransferItem {
         catch (UnparsableVersionException | UnsupportedAlgorithmException | InvalidBagitFileFormatException e) {
             throw new RuntimeException("Unable to read bag info from DVE: " + dve, e);
         }
+    }
+
+    private Optional<String> getFirstValue(Metadata metadata, String key) {
+        var values = metadata.get(key);
+        return (values != null && !values.isEmpty()) ? Optional.ofNullable(values.get(0)) : Optional.empty();
     }
 
     /**
@@ -270,14 +268,25 @@ public class TransferItem {
             return;
         }
 
-        var result = withTopLevelDir(topLevelDir -> {
-            var emailOpt = readBagInfoFirstValue(topLevelDir, "Contact-Email");
-            var nameOpt = readBagInfoFirstValue(topLevelDir, "Contact-Name");
-            return new String[] { emailOpt.orElse(null), nameOpt.orElse(null) };
+        withTopLevelDir(topLevelDir -> {
+            try {
+                var metadata = new BagReader().read(topLevelDir).getMetadata();
+
+                cachedContactEmail = getFirstValue(metadata, "Contact-Email")
+                    .filter(s -> !s.equalsIgnoreCase("N/A"))
+                    .or(() -> getFirstValue(metadata, "Organization-Email"))
+                    .orElse("no.email@dummy.org");
+
+                cachedContactName = getFirstValue(metadata, "Contact-Name")
+                    .filter(s -> !s.isBlank())
+                    .orElse(cachedContactEmail);
+
+                return null;
+            }
+            catch (IOException | MaliciousPathException | UnparsableVersionException | UnsupportedAlgorithmException | InvalidBagitFileFormatException e) {
+                throw new RuntimeException("Unable to read contact details from DVE bag", e);
+            }
         });
-        cachedContactEmail = result[0];
-        // Fallback to contact email when contact name is not available
-        cachedContactName = (result[1] != null && !result[1].isBlank()) ? result[1] : cachedContactEmail;
     }
 
     public String getNbn() throws IOException {

--- a/src/test/java/nl/knaw/dans/transfer/core/TransferItemTest.java
+++ b/src/test/java/nl/knaw/dans/transfer/core/TransferItemTest.java
@@ -269,6 +269,24 @@ public class TransferItemTest extends TestDirFixture {
     }
 
     @Test
+    public void getDeaccessionedReason_should_return_default_when_reason_is_blank() throws Exception {
+        var sourceDir = testDir.resolve("transfer-item-deacc-blank");
+        Files.createDirectories(sourceDir);
+        var dve = sourceDir.resolve("dataset_v1.zip");
+        createDveZip(dve,
+            "Contact Name",
+            "contact@example.org",
+            "urn:nbn:nl:ui:13-abcdef",
+            "doi:10.5072/FK2/ABCDEF:1.0",
+            null,
+            "DEACCESSIONED",
+            " ");
+
+        var item = new TransferItem(dve, new FileServiceImpl());
+        assertThat(item.getDeaccessionedReason()).contains("N/a");
+    }
+
+    @Test
     public void getDeaccessionedReason_should_return_empty_when_not_deaccessioned_or_missing() throws Exception {
         var sourceDir = testDir.resolve("transfer-item-not-deacc");
         Files.createDirectories(sourceDir);
@@ -313,7 +331,7 @@ public class TransferItemTest extends TestDirFixture {
         var manifestSha1 = "sha1-value-1  data/file1\n" +
                            "sha1-value-2  data/file2\n" +
                            "sha1-value-3  data/file3\n";
-        createDveZip(dve, null, null, "urn:nbn:nl:ui:13-fetch", null, null, null, null, fetchTxt, manifestSha1);
+        createDveZip(dve, null, null, null, "urn:nbn:nl:ui:13-fetch", null, null, null, null, fetchTxt, manifestSha1);
 
         var item = new TransferItem(dve, fileService);
 
@@ -331,7 +349,7 @@ public class TransferItemTest extends TestDirFixture {
         Files.createDirectories(sourceDir);
         var dve = sourceDir.resolve("dataset_v1.zip");
         var manifestSha1 = "sha1-value-1  data/file1\n";
-        createDveZip(dve, null, null, "urn:nbn:nl:ui:13-no-fetch", null, null, null, null, null, manifestSha1);
+        createDveZip(dve, null, null, null, "urn:nbn:nl:ui:13-no-fetch", null, null, null, null, null, manifestSha1);
 
         var item = new TransferItem(dve, fileService);
 
@@ -342,6 +360,62 @@ public class TransferItemTest extends TestDirFixture {
         assertThat(sha1s).isEmpty();
     }
 
+
+    @Test
+    public void getContactEmail_should_fallback_to_OrganizationEmail_when_ContactEmail_is_NA() throws Exception {
+        var sourceDir = testDir.resolve("contact-fallback-org");
+        Files.createDirectories(sourceDir);
+        var dve = sourceDir.resolve("dataset.zip");
+        createDveZip(dve, null, "N/A", "org@example.org", null, null, null);
+
+        var item = new TransferItem(dve, fileService);
+        assertThat(item.getContactEmail()).isEqualTo("org@example.org");
+        assertThat(item.getContactName()).isEqualTo("org@example.org");
+    }
+
+    @Test
+    public void getContactEmail_should_fallback_to_dummy_when_both_emails_are_NA() throws Exception {
+        var sourceDir = testDir.resolve("contact-fallback-dummy");
+        Files.createDirectories(sourceDir);
+        var dve = sourceDir.resolve("dataset.zip");
+        createDveZip(dve, null, "N/A", "N/A", null, null, null);
+
+        var item = new TransferItem(dve, fileService);
+        assertThat(item.getContactEmail()).isEqualTo("no.email@dummy.org");
+    }
+
+    @Test
+    public void getContactEmail_should_fallback_to_dummy_when_both_emails_are_blank_or_NA() throws Exception {
+        var sourceDir = testDir.resolve("contact-fallback-blank-na");
+        Files.createDirectories(sourceDir);
+        var dve = sourceDir.resolve("dataset.zip");
+        createDveZip(dve, null, " ", " N/A ", null, null, null);
+
+        var item = new TransferItem(dve, fileService);
+        assertThat(item.getContactEmail()).isEqualTo("no.email@dummy.org");
+    }
+
+    @Test
+    public void getContactEmail_should_trim_NA_case_insensitive() throws Exception {
+        var sourceDir = testDir.resolve("contact-fallback-trim");
+        Files.createDirectories(sourceDir);
+        var dve = sourceDir.resolve("dataset.zip");
+        createDveZip(dve, null, " n/a ", "org@example.org", null, null, null);
+
+        var item = new TransferItem(dve, fileService);
+        assertThat(item.getContactEmail()).isEqualTo("org@example.org");
+    }
+
+    @Test
+    public void getContactName_should_fallback_to_ContactEmail_when_ContactName_is_blank() throws Exception {
+        var sourceDir = testDir.resolve("contact-name-fallback-blank");
+        Files.createDirectories(sourceDir);
+        var dve = sourceDir.resolve("dataset.zip");
+        createDveZip(dve, " ", "contact@example.org", null, null, null);
+
+        var item = new TransferItem(dve, fileService);
+        assertThat(item.getContactName()).isEqualTo("contact@example.org");
+    }
 
     /**
      * Helper method to create a DVE zip file for testing purposes. Creates a minimal BagIt structure with bag-info.txt containing contact information and optionally an oai-ore.jsonld metadata file
@@ -356,15 +430,19 @@ public class TransferItemTest extends TestDirFixture {
      * @throws IOException if an I/O error occurs during zip creation
      */
     private static void createDveZip(Path zipPath, String contactName, String contactEmail, String nbn, String pidVersion, String hasOrganizationalIdentifierVersion) throws IOException {
-        createDveZip(zipPath, contactName, contactEmail, nbn, pidVersion, hasOrganizationalIdentifierVersion, null, null, null, null);
+        createDveZip(zipPath, contactName, contactEmail, null, nbn, pidVersion, hasOrganizationalIdentifierVersion, null, null, null, null);
+    }
+
+    private static void createDveZip(Path zipPath, String contactName, String contactEmail, String organizationEmail, String nbn, String pidVersion, String hasOrganizationalIdentifierVersion) throws IOException {
+        createDveZip(zipPath, contactName, contactEmail, organizationEmail, nbn, pidVersion, hasOrganizationalIdentifierVersion, null, null, null, null);
     }
 
     private static void createDveZip(Path zipPath, String contactName, String contactEmail, String nbn, String pidVersion, String hasOrganizationalIdentifierVersion,
                                      String creativeWorkStatusName, String deaccessionReason) throws IOException {
-        createDveZip(zipPath, contactName, contactEmail, nbn, pidVersion, hasOrganizationalIdentifierVersion, creativeWorkStatusName, deaccessionReason, null, null);
+        createDveZip(zipPath, contactName, contactEmail, null, nbn, pidVersion, hasOrganizationalIdentifierVersion, creativeWorkStatusName, deaccessionReason, null, null);
     }
 
-    private static void createDveZip(Path zipPath, String contactName, String contactEmail, String nbn, String pidVersion, String hasOrganizationalIdentifierVersion,
+    private static void createDveZip(Path zipPath, String contactName, String contactEmail, String organizationEmail, String nbn, String pidVersion, String hasOrganizationalIdentifierVersion,
                                      String creativeWorkStatusName, String deaccessionReason, String fetchTxt, String manifestSha1) throws IOException {
         var env = new HashMap<String, String>();
         env.put("create", "true");
@@ -382,6 +460,9 @@ public class TransferItemTest extends TestDirFixture {
             }
             if (contactEmail != null) {
                 bagInfo.append("Contact-Email: ").append(contactEmail).append("\n");
+            }
+            if (organizationEmail != null) {
+                bagInfo.append("Organization-Email: ").append(organizationEmail).append("\n");
             }
             if (hasOrganizationalIdentifierVersion != null) {
                 bagInfo.append("Has-Organizational-Identifier-Version: ").append(hasOrganizationalIdentifierVersion).append("\n");


### PR DESCRIPTION
Fixes DD-2373

# Description of changes
It turns out that the BagPack exporter in Dataverse will fill the `Contact-Email` field in `bag-info.txt` with `N/A` if no contact person was found in the dataset. This can happen with very old DataverseNL datasets. This code change implements the following logic to select the email for the OCFL object version:

Use `Contact-Email` if found and not `N/A`, otherwise use `Organization-Email`. As a last fallback use the string `no.email@dummy.org`.


# Notify
@DANS-KNAW/core-systems
